### PR TITLE
Make File Browser More Efficient

### DIFF
--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileBrowser.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileBrowser.java
@@ -55,24 +55,4 @@ public interface FileBrowser {
 	 */
 	public ArrayList<String> getFileList();
 
-	/**
-	 * This method returns the list of files and their relative paths to the passed
-	 * argument topDirectory. The argument should be the top-most directory that one
-	 * wants to search through.
-	 * 
-	 * @param topDirectory
-	 * @return
-	 */
-	public abstract ArrayList<String> listFiles(final String topDirectory);
-
-	/**
-	 * This method returns the list of directories and their relative paths to the
-	 * passed argument topDirectory. The argument should be the top-most directory
-	 * that one wants to search through.
-	 * 
-	 * @param topDirectory
-	 * @return
-	 */
-	public abstract ArrayList<String> listDirectories(final String topDirectory);
-
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
@@ -179,7 +179,7 @@ public abstract class FileHandler implements IFileHandler {
 	 * See {@link org.eclipse.ice.commands.IFileHandler#getFileBrowser()}
 	 */
 	@Override
-	public abstract FileBrowser getFileBrowser();
+	public abstract FileBrowser getFileBrowser(final String topDirectory);
 
 	/**
 	 * This function gets and returns the private member variable command of type

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/IFileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/IFileHandler.java
@@ -12,7 +12,7 @@
 package org.eclipse.ice.commands;
 
 import java.io.IOException;
-
+import org.eclipse.ice.commands.FileBrowser;
 /**
  * This interface defines and lays out the design for the FileHandler structures
  * responsible for moving and/or copying files to and from destinations.
@@ -69,7 +69,8 @@ public interface IFileHandler {
 	 * Method that returns a FileBrowser instance
 	 * 
 	 * @return - FileBrowser
+	 * @param  - Directory to browse
 	 */
-	public abstract FileBrowser getFileBrowser();
+	public abstract FileBrowser getFileBrowser(final String topDirectory);
 
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalFileBrowser.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalFileBrowser.java
@@ -36,8 +36,20 @@ public class LocalFileBrowser extends SimpleFileVisitor<Path> implements FileBro
 		fileList.clear();
 		directoryList.clear();
 	}
+	
+	/**
+	 * Default constructor with a given path to fill the ArrayLists
+	 */
+	public LocalFileBrowser(final String topDirectory) {
+		// Make sure we are starting with a fresh file/directory list
+		fileList.clear();
+		directoryList.clear();
+		// Execute the file walking logic, which fills the arrays
+		walkTree(topDirectory);
+		
+	}
 
-	// Add the file path tp fileList
+	// Add the file path to fileList
 	@Override
 	public FileVisitResult visitFile(Path file, BasicFileAttributes attr) {
 		// Add the file, depending on it's attribute
@@ -87,38 +99,12 @@ public class LocalFileBrowser extends SimpleFileVisitor<Path> implements FileBro
 	}
 
 	/**
-	 * See {@link org.eclipse.ice.commands.IFileHandler#listFiles(String)}
-	 */
-	@Override
-	public ArrayList<String> listFiles(String topDirectory) {
-		logger.info("Searching " + topDirectory);
-		// Execute the file walking logic
-		walkTree(topDirectory);
-
-		// Return the resulting file list hash map
-		return getFileList();
-	}
-
-	/**
-	 * See {@link org.eclipse.ice.commands.IFileHandler#listDirectories(String)}
-	 */
-	@Override
-	public ArrayList<String> listDirectories(String topDirectory) {
-		logger.info("Searching " + topDirectory);
-		// Executes the file walking logic
-		walkTree(topDirectory);
-
-		// Return the resulting directory array list
-		return getDirectoryList();
-	}
-
-	/**
 	 * This function performs the action of walking the file tree for the file
 	 * browsing capabilities of LocalFileHandler. It returns a LocalFileWalker so
 	 * that the files or directories could be obtained
 	 * 
 	 */
-	private void walkTree(String topDirectory) {
+	private void walkTree(final String topDirectory) {
 
 		// Make a path variable of the topDirectory
 		Path topPath = Paths.get(topDirectory);

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalFileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalFileHandler.java
@@ -91,8 +91,8 @@ public class LocalFileHandler extends FileHandler {
 	 * See {@link org.eclipse.ice.commands.IFileHandler#getFileBrowser()}
 	 */
 	@Override
-	public FileBrowser getFileBrowser() {
-		LocalFileBrowser browser = new LocalFileBrowser();
+	public FileBrowser getFileBrowser(final String topDirectory) {
+		LocalFileBrowser browser = new LocalFileBrowser(topDirectory);
 		return browser;
 	}
 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteFileBrowser.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteFileBrowser.java
@@ -32,13 +32,25 @@ public class RemoteFileBrowser implements FileBrowser {
 	private Connection connection;
 
 	/**
-	 * Default constructor
+	 * Default  constructor
 	 */
-	public RemoteFileBrowser(Connection connection) {
-		// Make sure we start with a fresh list everytime the walker is called
+	public RemoteFileBrowser() {
+		fileList.clear();
+		directoryList.clear();
+		this.connection = null;
+	}
+	
+	/**
+	 * Default constructor with connection and top directory name
+	 */
+	public RemoteFileBrowser(Connection connection, final String topDirectory) {
+		// Make sure we start with a fresh list every time the browser is called
 		fileList.clear();
 		directoryList.clear();
 		this.connection = connection;
+		
+		// Fill the arrays with the relevant file information
+		fillArrays(topDirectory, connection.getSftpChannel());
 	}
 
 	/**
@@ -103,26 +115,6 @@ public class RemoteFileBrowser implements FileBrowser {
 	@Override
 	public ArrayList<String> getFileList() {
 		return fileList;
-	}
-
-	/**
-	 * See {@link org.eclipse.ice.commands.FileBrowser#listFiles(String)}
-	 */
-	@Override
-	public ArrayList<String> listFiles(final String topDirectory) {
-		fillArrays(topDirectory, connection.getSftpChannel());
-
-		return getFileList();
-	}
-
-	/**
-	 * See {@link org.eclipse.ice.commands.FileBrowser#listDirectories(String)}
-	 */
-	@Override
-	public ArrayList<String> listDirectories(final String topDirectory) {
-		fillArrays(topDirectory, connection.getSftpChannel());
-
-		return getDirectoryList();
 	}
 
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteFileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteFileHandler.java
@@ -327,8 +327,8 @@ public class RemoteFileHandler extends FileHandler {
 	 * See {@link org.eclipse.ice.commands.IFileHandler#getFileBrowser()}
 	 */
 	@Override
-	public FileBrowser getFileBrowser() {
-		RemoteFileBrowser browser = new RemoteFileBrowser(connection.get());
+	public FileBrowser getFileBrowser(final String topDirectory) {
+		RemoteFileBrowser browser = new RemoteFileBrowser(connection.get(), topDirectory);
 		return browser;
 	}
 

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalFileBrowserTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalFileBrowserTest.java
@@ -38,34 +38,6 @@ import org.junit.Test;
 public class LocalFileBrowserTest {
 
 	/**
-	 * @throws java.lang.Exception
-	 */
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
-	}
-
-	/**
-	 * @throws java.lang.Exception
-	 */
-	@AfterClass
-	public static void tearDownAfterClass() throws Exception {
-	}
-
-	/**
-	 * @throws java.lang.Exception
-	 */
-	@Before
-	public void setUp() throws Exception {
-	}
-
-	/**
-	 * @throws java.lang.Exception
-	 */
-	@After
-	public void tearDown() throws Exception {
-	}
-
-	/**
 	 * Function to execute the local file browsing and local directory browsing
 	 * test. We call one main function so that a file structur can be created at the
 	 * beginning, accessed by both "subtests", and then deleted at the end.
@@ -91,10 +63,11 @@ public class LocalFileBrowserTest {
 	 * @throws IOException
 	 */
 	public void testLocalFileBrowsing(Path topPath) throws IOException {
-		LocalFileBrowser browser = new LocalFileBrowser();
+		LocalFileBrowser browser = new LocalFileBrowser(topPath.toString());
+		// Get a file handler for existence checks
 		LocalFileHandler handler = new LocalFileHandler();
 
-		ArrayList<String> files = browser.listFiles(topPath.toString());
+		ArrayList<String> files = browser.getFileList();
 
 		// four files were created
 		assert (files.size() == 4);
@@ -118,9 +91,9 @@ public class LocalFileBrowserTest {
 	 */
 	public void testLocalDirectoryBrowsing(Path topPath) throws IOException {
 		LocalFileHandler handler = new LocalFileHandler();
-		LocalFileBrowser browser = new LocalFileBrowser();
+		LocalFileBrowser browser = new LocalFileBrowser(topPath.toString());
 
-		ArrayList<String> files = browser.listDirectories(topPath.toString());
+		ArrayList<String> files = browser.getDirectoryList();
 		for (int i = 0; i < files.size(); i++) {
 			System.out.println(files.get(i));
 		}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteFileBrowserTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteFileBrowserTest.java
@@ -75,7 +75,6 @@ public class RemoteFileBrowserTest {
 	}
 
 	/**
-<<<<<<< HEAD
 	 * @throws java.lang.Exception
 	 */
 	@AfterClass
@@ -84,22 +83,6 @@ public class RemoteFileBrowserTest {
 	}
 
 	/**
-	 * @throws java.lang.Exception
-	 */
-	@Before
-	public void setUp() throws Exception {
-	}
-
-	/**
-	 * @throws java.lang.Exception
-	 */
-	@After
-	public void tearDown() throws Exception {
-	}
-
-	/**
-=======
->>>>>>> 354a0ec8cad995c7e88a1f5ace79c97b811f1381
 	 * Function to execute the remote file browsing and remote directory browsing
 	 * test. We call one main function so that a file structure can be created at
 	 * the beginning of the test, accessed by both "subtests", and then deleted at
@@ -137,11 +120,11 @@ public class RemoteFileBrowserTest {
 	public void testRemoteFileBrowsing(String topDirectory) throws IOException, SftpException {
 
 		RemoteFileHandler handler = new RemoteFileHandler();
-		RemoteFileBrowser browser = new RemoteFileBrowser(fileTransferConn);
+		RemoteFileBrowser browser = new RemoteFileBrowser(fileTransferConn, topDirectory);
 
 		handler.setConnectionConfiguration(fileTransferConn.getConfiguration());
 
-		ArrayList<String> files = browser.listFiles(topDirectory);
+		ArrayList<String> files = browser.getFileList();
 
 		// files should only be 4 entries since there are only 4 files in the tree
 		// structure we created
@@ -171,9 +154,9 @@ public class RemoteFileBrowserTest {
 
 		RemoteFileHandler handler = new RemoteFileHandler();
 		handler.setConnectionConfiguration(fileTransferConn.getConfiguration());
-		RemoteFileBrowser browser = new RemoteFileBrowser(fileTransferConn);
+		RemoteFileBrowser browser = new RemoteFileBrowser(fileTransferConn, topDirectory);
 
-		ArrayList<String> files = browser.listDirectories(topDirectory);
+		ArrayList<String> files = browser.getDirectoryList();
 
 		// directories should only be 3 entries since there are only 3 directories in
 		// the tree structure we created


### PR DESCRIPTION
Refactored the FileBrowsing code to be more efficient. Now, rather than being called with a directory, a FileBrowser is created with a particular directory so that the file browsing only happens one time. Thus, for a given directory, the tree structure is only determined once rather than twice (or whenever a call is made to find files).

Signed-off-by: Joe Osborn <osbornjd@ornl.gov>