### PR TITLE
Jump host commands

### DIFF
--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
@@ -161,7 +161,7 @@ public abstract class Command {
 	 * This function is intended to clean up any (possible) remaining loose ends
 	 * after the job is finished processing.
 	 * 
-	 * @return
+	 * @return CommandStatus - indicating that the configuration completed clean up
 	 */
 	protected CommandStatus cleanUp() {
 
@@ -182,7 +182,7 @@ public abstract class Command {
 	 * log/error information.
 	 * 
 	 * @return - CommandStatus indicating that configuration completed and job can
-	 *         start running
+	 *           start running
 	 */
 	protected CommandStatus setConfiguration() {
 
@@ -330,7 +330,7 @@ public abstract class Command {
 	 * This function is a simple helper function to check and make sure that the
 	 * command status is not set to a flagged error, e.g. failed.
 	 * 
-	 * @param current_status
+	 * @param current_status to be checked
 	 * @return boolean indicating whether or not status is good to continue (true)
 	 *         or whether or not job has failed (returns false)
 	 */
@@ -371,7 +371,7 @@ public abstract class Command {
 	 * This function returns to the user the configuration that was used to create a
 	 * particular command.
 	 * 
-	 * @return - the particular configuration for this command
+	 * @return - the particular CommandConfiguration for this command
 	 */
 	public CommandConfiguration getCommandConfiguration() {
 		return commandConfig;
@@ -380,7 +380,7 @@ public abstract class Command {
 	/**
 	 * This function sets the command configuration for a particular command
 	 * 
-	 * @param config
+	 * @param commandConfig - CommandConfiguration to be set
 	 */
 	public void setCommandConfiguration(CommandConfiguration commandConfig) {
 		this.commandConfig = commandConfig;
@@ -400,7 +400,7 @@ public abstract class Command {
 	 * This function sets the configuration that is to be used to set up a
 	 * particular connection.
 	 * 
-	 * @param connect
+	 * @param connectionConfig - ConnectionConfiguration to be set
 	 */
 	public void setConnectionConfiguration(ConnectionConfiguration connectionConfig) {
 		this.connectionConfig = connectionConfig;

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandConfiguration.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandConfiguration.java
@@ -73,10 +73,10 @@ public class CommandConfiguration {
 	private HashMap<String, String> inputFiles = new HashMap<String, String>();
 
 	/**
-	 * This is a list of arguments that the user might want to append to the executable
-	 * name that are _not_ input files. These will not be explicitly checked by the 
-	 * file handler for whether or not they exist, as they are presumed to be 
-	 * flags/arguments for the job to run.
+	 * This is a list of arguments that the user might want to append to the
+	 * executable name that are _not_ input files. These will not be explicitly
+	 * checked by the file handler for whether or not they exist, as they are
+	 * presumed to be flags/arguments for the job to run.
 	 */
 	private ArrayList<String> argumentList = new ArrayList<String>();
 	/**
@@ -308,16 +308,16 @@ public class CommandConfiguration {
 		String separator = "/";
 
 		// Add the arguments to the executable name
-		for(String arg : argumentList) {
+		for (String arg : argumentList) {
 			fixedExecutableName += " " + arg;
 		}
-		
+
 		// If the input files should be appended, append it
 		if (appendInput)
 			fixedExecutableName += " " + getInputFiles();
 
 		fullCommand = fixedExecutableName;
-		
+
 		// Determine the proper separator
 		if (installDirectory != null && installDirectory.contains(":\\"))
 			separator = "\\";
@@ -326,8 +326,6 @@ public class CommandConfiguration {
 		if (installDirectory != null && !installDirectory.endsWith(separator))
 			installDirectory = installDirectory + separator;
 
-
-		
 		// Search for and replace the ${inputFile} to properly configure the input file
 		for (Map.Entry<String, String> entry : inputFiles.entrySet()) {
 			if (fixedExecutableName.contains("${" + entry.getKey() + "}") && !appendInput)
@@ -374,7 +372,7 @@ public class CommandConfiguration {
 	 * Setter for CommandId, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#commandId}
 	 * 
-	 * @param _commandId
+	 * @param commandId - integer of command ID to be run
 	 */
 	public void setCommandId(int commandId) {
 		this.commandId = commandId;
@@ -385,7 +383,7 @@ public class CommandConfiguration {
 	 * Getter for CommandId, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#commandId}
 	 * 
-	 * @return commandId
+	 * @return commandId - CommandConfiguration ID
 	 */
 	public int getCommandId() {
 		return commandId;
@@ -395,7 +393,7 @@ public class CommandConfiguration {
 	 * Setter for executable, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#executable}
 	 * 
-	 * @param exec
+	 * @param executable - executable to be run
 	 */
 	public void setExecutable(String executable) {
 		this.executable = executable;
@@ -406,17 +404,18 @@ public class CommandConfiguration {
 	 * Getter for executable, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#executable}
 	 * 
-	 * @return executable
+	 * @return executable - executable to be run
 	 */
 	public String getExecutable() {
 		return executable;
 	}
 
 	/**
-	 * Setter for inputFile, see
+	 * Adder for inputFile, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#inputFile}
 	 * 
-	 * @param input
+	 * @param name - name of inputFile to add
+	 * @param path - path to inputFile relative to workingDirectory
 	 */
 	public void addInputFile(String name, String path) {
 		inputFiles.put(name, path);
@@ -427,7 +426,7 @@ public class CommandConfiguration {
 	 * Getter for a concatenated string of inputFiles, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#inputFiles}
 	 * 
-	 * @return inputFile
+	 * @return String - a string of all the inputFiles concatenated
 	 */
 	public String getInputFiles() {
 		String files = "";
@@ -441,7 +440,7 @@ public class CommandConfiguration {
 	 * Getter for the inputFile hashmap itself, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#inputFiles}
 	 * 
-	 * @return inputFile
+	 * @return inputFile - Hashmap with input file list
 	 */
 	public HashMap<String, String> getInputFileList() {
 		return inputFiles;
@@ -451,7 +450,7 @@ public class CommandConfiguration {
 	 * Setter for stdErrFileName, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#stdErrFileName}
 	 * 
-	 * @param errFile
+	 * @param stdErrFileName - name for StdErr file
 	 */
 	public void setErrFileName(String stdErrFileName) {
 		this.stdErrFileName = stdErrFileName;
@@ -462,7 +461,7 @@ public class CommandConfiguration {
 	 * Getter for stdErrFileName, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#stdErrFileName}
 	 * 
-	 * @return stdErrFileName
+	 * @return stdErrFileName - name of StdErr file
 	 */
 	public String getErrFileName() {
 		return stdErrFileName;
@@ -472,7 +471,7 @@ public class CommandConfiguration {
 	 * Setter for stdOutFileName, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#stdOutFileName}
 	 * 
-	 * @param outFile
+	 * @param outFile - name of StdOut file
 	 */
 	public void setOutFileName(String stdOutFileName) {
 		this.stdOutFileName = stdOutFileName;
@@ -483,7 +482,7 @@ public class CommandConfiguration {
 	 * Getter for stdOutFileName, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#stdOutFileName}
 	 * 
-	 * @return stdOutFileName
+	 * @return stdOutFileName - name of StdOut file
 	 */
 	public String getOutFileName() {
 		return stdOutFileName;
@@ -493,7 +492,7 @@ public class CommandConfiguration {
 	 * Setter for numProcs, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#numProcs}
 	 * 
-	 * @param procs
+	 * @param numProcs - number of processes
 	 */
 	public void setNumProcs(String numProcs) {
 		this.numProcs = numProcs;
@@ -504,7 +503,7 @@ public class CommandConfiguration {
 	 * Getter for numProcs, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#numProcs}
 	 * 
-	 * @return numProcs
+	 * @return numProcs - number of processes
 	 */
 	public String getNumProcs() {
 		return numProcs;
@@ -514,7 +513,7 @@ public class CommandConfiguration {
 	 * Setter for installDirectory, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#installDirectory}
 	 * 
-	 * @param installDir
+	 * @param installDir - String corresponding to path of install directory
 	 */
 	public void setInstallDirectory(String installDirectory) {
 		this.installDirectory = installDirectory;
@@ -525,7 +524,7 @@ public class CommandConfiguration {
 	 * Getter for installDirectory, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#installDirectory}
 	 * 
-	 * @return installDirectory
+	 * @return installDirectory - path of install directory
 	 */
 	public String getInstallDirectory() {
 		return installDirectory;
@@ -535,7 +534,7 @@ public class CommandConfiguration {
 	 * Getter for os, see {@link org.eclipse.ice.commands.CommandConfiguration#os}
 	 * Note that this is set to the default of the local OS
 	 * 
-	 * @return os
+	 * @return os - operating system that Command is running on
 	 */
 	public String getOS() {
 		return os;
@@ -545,7 +544,7 @@ public class CommandConfiguration {
 	 * Setter for operating system, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#os}
 	 * 
-	 * @param OS
+	 * @param os - operating system that Command is running on
 	 */
 	public void setOS(String os) {
 		this.os = os;
@@ -555,11 +554,15 @@ public class CommandConfiguration {
 	 * Setter for workingDirectory, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#workingDirectory}
 	 * 
-	 * @param workingDir
+	 * @param workingDir - working directory containing input files/scripts
 	 */
 	public void setWorkingDirectory(String workingDirectory) {
 		// Check to see if the directory ends with a separator
 		String separator = FileSystems.getDefault().getSeparator();
+		// Make a special case for windows
+		if (workingDirectory.contains("\\"))
+			separator = "\\";
+
 		if (!workingDirectory.endsWith(separator))
 			workingDirectory += separator;
 		this.workingDirectory = workingDirectory;
@@ -570,7 +573,7 @@ public class CommandConfiguration {
 	 * Getter for workingDirectory, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#workingDirectory}
 	 * 
-	 * @return workingDirectory
+	 * @return workingDirectory - working directory containing files/scripts
 	 */
 	public String getWorkingDirectory() {
 		return workingDirectory;
@@ -580,7 +583,8 @@ public class CommandConfiguration {
 	 * Setter for appendInput, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#appendInput}
 	 * 
-	 * @param _appendInput
+	 * @param appendInput - boolean of whether or not to append input file names to
+	 *                    executable
 	 */
 	public void setAppendInput(boolean appendInput) {
 		this.appendInput = appendInput;
@@ -591,7 +595,8 @@ public class CommandConfiguration {
 	 * Getter for appendInput, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#appendInput}
 	 * 
-	 * @return appendInput
+	 * @return appendInput - boolean of whether or not to append input file names to
+	 *         executable
 	 */
 	public boolean getAppendInput() {
 		return appendInput;
@@ -603,7 +608,7 @@ public class CommandConfiguration {
 	 * setter protected with the intent that only ConnectionConfiguration can modify
 	 * this member variable.
 	 * 
-	 * @param host
+	 * @param hostname - hostname for command to run on
 	 */
 	protected void setHostname(String hostname) {
 		this.hostname = hostname;
@@ -614,7 +619,7 @@ public class CommandConfiguration {
 	 * Getter for hostname, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#hostname}.
 	 * 
-	 * @return
+	 * @return hostname - hostname for command to run on
 	 */
 	public String getHostname() {
 		return hostname;
@@ -624,7 +629,7 @@ public class CommandConfiguration {
 	 * Setter for stdErr, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#stdErr}
 	 * 
-	 * @param writer
+	 * @param stdErr - BufferedWriter to write error output
 	 */
 	public void setStdErr(BufferedWriter stdErr) {
 		this.stdErr = stdErr;
@@ -635,7 +640,7 @@ public class CommandConfiguration {
 	 * Getter for stdErr, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#stdErr}
 	 * 
-	 * @return stdErr
+	 * @return stdErr - Buffered writer to write error output
 	 */
 	public BufferedWriter getStdErr() {
 		return stdErr;
@@ -645,7 +650,7 @@ public class CommandConfiguration {
 	 * Setter for stdOut, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#stdOut}
 	 * 
-	 * @param writer
+	 * @param stdOut - BufferedWriter to write log output
 	 */
 	public void setStdOut(BufferedWriter stdOut) {
 		this.stdOut = stdOut;
@@ -656,7 +661,7 @@ public class CommandConfiguration {
 	 * Getter for stdOut, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#stdOut}
 	 * 
-	 * @return stdOut
+	 * @return stdOut - BufferedWriter to write log output
 	 */
 	public BufferedWriter getStdOut() {
 		return stdOut;
@@ -666,7 +671,7 @@ public class CommandConfiguration {
 	 * Setter for stdOutput, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#stdOutput}
 	 * 
-	 * @return stdOutput
+	 * @return stdOutput - String for StdOutput name
 	 */
 	public void setStdOutputString(String stdOutput) {
 		this.stdOutput = stdOutput;
@@ -676,7 +681,7 @@ public class CommandConfiguration {
 	 * This function adds the String string to the String
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#stdOutput}
 	 * 
-	 * @param string
+	 * @param string - String to concatenate to the stdOutput string
 	 */
 	public void addToStdOutputString(String string) {
 		stdOutput += "\n" + string;
@@ -686,7 +691,7 @@ public class CommandConfiguration {
 	 * Getter for stdOutput, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#stdOutput}
 	 * 
-	 * @return stdOutput
+	 * @return stdOutput - String of all stdOutput, separated by '\n'
 	 */
 	public String getStdOutputString() {
 		return stdOutput;
@@ -694,9 +699,11 @@ public class CommandConfiguration {
 
 	/**
 	 * Getter for splitCommand, see
-	 * {@link org.eclipse.ice.commands.CommandConfiguration#splitCommand} No setter
+	 * {@link org.eclipse.ice.commands.CommandConfiguration#splitCommand}. No setter
 	 * since splitCommand is determined by
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#getExecutableName()}
+	 * 
+	 * @return splitCommand - ArrayList<String> of split commands
 	 */
 	public ArrayList<String> getSplitCommand() {
 		return splitCommand;
@@ -708,9 +715,8 @@ public class CommandConfiguration {
 	 * the setter for full command protected so that it can only be accessed within
 	 * the package and not by (e.g.) the user
 	 * 
-	 * @param command
+	 * @param fullComand - String of the full command to be executed
 	 *
-	 * 
 	 */
 	protected void setFullCommand(String fullCommand) {
 		this.fullCommand = fullCommand;
@@ -721,7 +727,7 @@ public class CommandConfiguration {
 	 * Getter for fullCommand, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#fullCommand}
 	 * 
-	 * @return fullCommand
+	 * @return fullCommand - String of the full command to be executed
 	 */
 	public String getFullCommand() {
 		return fullCommand;
@@ -731,7 +737,7 @@ public class CommandConfiguration {
 	 * Add to error message string, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#errMsg}
 	 * 
-	 * @param
+	 * @param errMsg - String to add to the error message string
 	 */
 	public void addToErrString(String errMsg) {
 		this.errMsg += errMsg;
@@ -741,7 +747,7 @@ public class CommandConfiguration {
 	 * Setter for error message string, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#errMsg}
 	 * 
-	 * @param
+	 * @param errMsg - String to add to the error message string
 	 */
 	public void setErrString(String errMsg) {
 		this.errMsg = errMsg;
@@ -751,7 +757,7 @@ public class CommandConfiguration {
 	 * Getter for error message string, see
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#errMsg}
 	 * 
-	 * @return
+	 * @return - String of error message
 	 */
 	public String getErrString() {
 		return errMsg;
@@ -761,7 +767,7 @@ public class CommandConfiguration {
 	 * Setter for the remote working directory
 	 * {@link org.eclipse.ice.commands.ConnectionConfiguration#workingDirectory}
 	 * 
-	 * @param dir
+	 * @param remoteWorkingDirectory - path for remote working directory
 	 */
 	public void setRemoteWorkingDirectory(String remoteWorkingDirectory) {
 		this.remoteWorkingDirectory = remoteWorkingDirectory;
@@ -771,7 +777,7 @@ public class CommandConfiguration {
 	 * Getter for the remote working directory
 	 * {@link org.eclipse.ice.commands.ConnectionConfiguration#workingDirectory}
 	 * 
-	 * @return
+	 * @return remoteWorkingDirectory - path for remote working directory
 	 */
 	public String getRemoteWorkingDirectory() {
 		return remoteWorkingDirectory;
@@ -781,7 +787,7 @@ public class CommandConfiguration {
 	 * Setter for interpreter
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#interpreter}
 	 * 
-	 * @param interpreter
+	 * @param interpreter - string of the interpreter to be used for this command
 	 */
 	public void setInterpreter(String interpreter) {
 		this.interpreter = interpreter;
@@ -791,26 +797,29 @@ public class CommandConfiguration {
 	 * Getter for interpreter
 	 * {@link org.eclipse.ice.commands.CommandConfiguration#interpreter}
 	 * 
-	 * @return
+	 * @return - interpreter to be used for this command
 	 */
 	public String getInterpreter() {
 		return interpreter;
 	}
-	
+
 	/**
-	 * Getter for argument list {@link org.eclipse.ice.commands.CommandConfiguration#argumentList}
-	 * @return
+	 * Getter for argument list
+	 * {@link org.eclipse.ice.commands.CommandConfiguration#argumentList}
+	 * 
+	 * @return - ArrayList<String> of the argument list
 	 */
-	public ArrayList<String> getArgumentList(){
+	public ArrayList<String> getArgumentList() {
 		return argumentList;
 	}
 
 	/**
 	 * Function that adds an argument to the argument list
-	 * @param argument
+	 * 
+	 * @param argument - argument to be added
 	 */
 	public void addArgument(String argument) {
 		argumentList.add(argument);
 	}
-	
+
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandConfiguration.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandConfiguration.java
@@ -558,7 +558,10 @@ public class CommandConfiguration {
 	 */
 	public void setWorkingDirectory(String workingDirectory) {
 		// Check to see if the directory ends with a separator
-		String separator = FileSystems.getDefault().getSeparator();
+		// Just get the one that corresponds to the string. In the case of
+		// commands which are running on *nix but starting on windows,
+		// or vice versa, this can get things mixed up
+		String separator = "/";
 		// Make a special case for windows
 		if (workingDirectory.contains("\\"))
 			separator = "\\";

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandFactory.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandFactory.java
@@ -48,16 +48,17 @@ public class CommandFactory {
 	 * another host to execute a command. See also
 	 * {@link org.eclipse.ice.commands.CommandFactory#getCommand(CommandConfiguration, ConnectionConfiguration, ConnectionConfiguration)
 	 * 
-	 * @param commandConfig
-	 * @param connectConfig
-	 * @return
-	 * @throws IOException
+	 * @param commandConfig    - the CommandConfiguration which holds the particular
+	 *                           details of a given command.
+	 * @param connectionConfig - the ConnectionConfiguration which holds the details
+	 *                           on the connection (i.e. local vs. remote)
+	 * @return                 - The command to be processed
 	 */
-	public Command getCommand(final CommandConfiguration commandConfig, final ConnectionConfiguration connectConfig)
+	public Command getCommand(final CommandConfiguration commandConfig, final ConnectionConfiguration connectionConfig)
 			throws IOException {
 		// pass null since the connection configuration connects us from the local host
 		// to the remote host, and we don't have an intermediary host
-		return getCommand(commandConfig, connectConfig, null);
+		return getCommand(commandConfig, connectionConfig, null);
 	}
 
 	/**
@@ -65,15 +66,15 @@ public class CommandFactory {
 	 * Command class {@link org.eclipse.ice.commands.Command}.
 	 * 
 	 * @param commandConfig           - the CommandConfiguration which holds the
-	 *                                particular details of a given command.
+	 *                                  particular details of a given command.
 	 * @param ConnectionConfiguration - the ConnectionConfiguration which holds the
-	 *                                details on the connection (i.e. local vs.
-	 *                                remote)
+	 *                                  details on the connection (i.e. local vs.
+	 *                                  remote)
 	 * @param extraConnection         - An additional connection configuration if
-	 *                                the user wants to "hop" connections, i.e. log
-	 *                                into one host and then send a job from that
-	 *                                host to an additional remote host
-	 * @return
+	 *                                  the user wants to "hop" connections, i.e. log
+	 *                                  into one host and then send a job from that
+	 *                                  host to an additional remote host
+	 * @return                        - The command to be processed
 	 * @throws IOException
 	 */
 	public Command getCommand(final CommandConfiguration commandConfig, final ConnectionConfiguration connectionConfig,
@@ -109,9 +110,9 @@ public class CommandFactory {
 	 * A function to check whether or not the provided hostname by the user in
 	 * CommandFactory is a local hostname or remote hostname.
 	 * 
-	 * @param host - String of the hostname to be checked
+	 * @param host     - String of the hostname to be checked
 	 * @return boolean - returns true if the hostname matches that of the local
-	 *         hostname, false otherwise.
+	 *                   hostname, false otherwise.
 	 */
 	private boolean isLocal(String host) {
 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandStatus.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandStatus.java
@@ -40,9 +40,6 @@ package org.eclipse.ice.commands;
  *
  */
 
-
-
-
 public enum CommandStatus{
 	SUCCESS, PROCESSING, RUNNING, INFOERROR, FAILED, CANCELED;
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Connection.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Connection.java
@@ -32,7 +32,8 @@ public class Connection {
 	 * An AtomicReference to the ConnectionConfiguration from which connection
 	 * information can be gathered
 	 */
-	private AtomicReference<ConnectionConfiguration> configuration = new AtomicReference<ConnectionConfiguration>(null);;
+	private AtomicReference<ConnectionConfiguration> configuration = new AtomicReference<ConnectionConfiguration>(
+			null);;
 
 	/**
 	 * The client entry point
@@ -74,7 +75,7 @@ public class Connection {
 	 * Constructor which actually sets the connection configuration to a passed
 	 * argument
 	 * 
-	 * @param config
+	 * @param config - the configuration to set the connection information
 	 */
 	public Connection(ConnectionConfiguration config) {
 		configuration = new AtomicReference<ConnectionConfiguration>(config);
@@ -83,20 +84,38 @@ public class Connection {
 	/**
 	 * Get and return the connection configuration
 	 * 
-	 * @return
+	 * @return - the Connection's ConnectionConfiguration
 	 */
 	public ConnectionConfiguration getConfiguration() {
 		return configuration.get();
 	}
 
+	/**
+	 * Set the configuration, see
+	 * {@link org.eclipse.ice.commands.Connection#configuration}
+	 * 
+	 * @param configuration - ConnectionConfiguration to set for this connection
+	 */
 	public void setConfiguration(ConnectionConfiguration configuration) {
 		this.configuration.set(configuration);
 	}
-	
+
+	/**
+	 * Getter to return the SshClient entry point in Mina, see
+	 * {@link org.eclipse.ice.commands.Connection#client}
+	 * 
+	 * @return - The Connection's SshClient
+	 */
 	public SshClient getClient() {
 		return client.get();
 	}
-	
+
+	/**
+	 * Setter for the SshClient entry point in Mina, see
+	 * {@link org.eclipse.ice.commands.Connection#client}
+	 * 
+	 * @param client - The Connection's SshClient
+	 */
 	public void setClient(SshClient client) {
 		this.client.set(client);
 	}
@@ -104,16 +123,16 @@ public class Connection {
 	/**
 	 * Get the sftp channel {@link org.eclipse.ice.commands.Connection#sftpChannel}
 	 * 
-	 * @return
+	 * @return - The Connection's sftp client
 	 */
 	public SftpClient getSftpChannel() {
 		return sftpClient.get();
 	}
-	
+
 	/**
 	 * Set the sftp channel {@link org.eclipse.ice.commands.Connection#sftpChannel}
 	 * 
-	 * @param sftpChannel
+	 * @param sftpChannel - the Connection's sftp client
 	 */
 	public void setSftpChannel(SftpClient sftpClient) {
 		this.sftpClient.set(sftpClient);
@@ -123,7 +142,7 @@ public class Connection {
 	 * Get the execution channel
 	 * {@link org.eclipse.ice.commands.Connection#execChannel}
 	 * 
-	 * @return
+	 * @return - the execution channel for this Connection
 	 */
 	public ChannelExec getExecChannel() {
 		return execChannel.get();
@@ -133,7 +152,7 @@ public class Connection {
 	 * Set the execution channel
 	 * {@link org.eclipse.ice.commands.Connection#execChannel}
 	 * 
-	 * @param execChannel
+	 * @param execChannel - the execution channel for this Connection
 	 */
 	public void setExecChannel(ChannelExec execChannel) {
 		this.execChannel.set(execChannel);
@@ -151,7 +170,7 @@ public class Connection {
 	/**
 	 * Set the session {@link org.eclipse.ice.commands.Connection#session}
 	 * 
-	 * @param _session
+	 * @param session - this connection's session
 	 */
 	public void setSession(ClientSession session) {
 		clientSession.set(session);
@@ -160,7 +179,7 @@ public class Connection {
 	/**
 	 * Set the input stream {@link org.eclipse.ice.commands.Connection#inputStream}
 	 * 
-	 * @param _stream
+	 * @param inputStream - this Connection's input stream for logging
 	 */
 	public void setInputStream(InputStream inputStream) {
 		this.inputStream = inputStream;
@@ -169,7 +188,7 @@ public class Connection {
 	/**
 	 * Get the input stream {@link org.eclipse.ice.commands.Connection#inputStream}
 	 * 
-	 * @return
+	 * @return - this Connection's input stream for logging
 	 */
 	public InputStream getInputStream() {
 		return inputStream;
@@ -179,7 +198,7 @@ public class Connection {
 	 * Set the output stream
 	 * {@link org.eclipse.ice.commands.Connection#outputStream}
 	 * 
-	 * @param _stream
+	 * @param outputStream - this Connection's output stream for logging
 	 */
 	public void setOutputStream(OutputStream outputStream) {
 		this.outputStream = outputStream;
@@ -189,7 +208,7 @@ public class Connection {
 	 * Get the output stream
 	 * {@link org.eclipse.ice.commands.Connection#outputStream}
 	 * 
-	 * @return
+	 * @return outputStream - this Connection's output stream for logging
 	 */
 	public OutputStream getOutputStream() {
 		return outputStream;

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionAuthorizationHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionAuthorizationHandler.java
@@ -43,20 +43,21 @@ public abstract class ConnectionAuthorizationHandler {
 	String hostname = null;
 
 	/**
-	 * A char array which can hold a password should the user desire. It is not 
+	 * A char array which can hold a password should the user desire. It is not
 	 * recommended to use this since this stores the password in memory for some
 	 * time. Rather, it is recommended to use any subclass of this class other than
-	 * BasicConnectionAuthorizationHandler, which retrieves the password from the user in some way, or use
-	 * the private key functionality for establishing a connection as in 
+	 * BasicConnectionAuthorizationHandler, which retrieves the password from the
+	 * user in some way, or use the private key functionality for establishing a
+	 * connection as in
 	 * {@link org.eclipse.ice.commands.ConnectionManagerTest#testOpenConnectionKeyPath}.
-	 * Note that in all other implementations of getPassword other than in 
-	 * BasicConnectionAuthorizationHandler, the password is not actually
-	 * stored in this char[] and is rather obtained where it is needed to establish
-	 * a connection and then immediately destroyed. Regardless, after the JSch connection
-	 * is established this member variable is set to null in all cases.
+	 * Note that in all other implementations of getPassword other than in
+	 * BasicConnectionAuthorizationHandler, the password is not actually stored in
+	 * this char[] and is rather obtained where it is needed to establish a
+	 * connection and then immediately destroyed. Regardless, after the JSch
+	 * connection is established this member variable is set to null in all cases.
 	 */
 	char[] password = null;
-	
+
 	/**
 	 * This function gets a password for the command authentication. The password is
 	 * returned in a char array since Strings are immutable, so it is generally ill
@@ -69,21 +70,22 @@ public abstract class ConnectionAuthorizationHandler {
 	protected abstract char[] getPassword();
 
 	/**
-	 * This function is intended to be a "jack of all trades" function where an option
-	 * can be passed that may be specific to a particular subclass. For example, for
-	 * text file authorization, a path to the text file can be passed as specified
-	 * by the subclass. The purpose of this function is for ease of setting things
-	 * in the factory method.
+	 * This function is intended to be a "jack of all trades" function where an
+	 * option can be passed that may be specific to a particular subclass. For
+	 * example, for text file authorization, a path to the text file can be passed
+	 * as specified by the subclass. The purpose of this function is for ease of
+	 * setting things in the factory method.
 	 * 
-	 * @param option
+	 * @param option - a multi-purpose option which depends on the subclass'
+	 *               implementation
 	 */
 	public abstract void setOption(String option);
-	
+
 	/**
 	 * Getter for authorization hostname
 	 * {@link org.eclipse.ice.commands.ConnectionAuthorizationHandler#hostname}
 	 * 
-	 * @return
+	 * @return hostname - hostname for this authorization
 	 */
 	public String getHostname() {
 		return hostname;
@@ -93,7 +95,7 @@ public abstract class ConnectionAuthorizationHandler {
 	 * Getter for authorization hostname
 	 * {@link org.eclipse.ice.commands.ConnectionAuthorizationHandler#username}
 	 * 
-	 * @return
+	 * @return username - username for this authorization
 	 */
 	public String getUsername() {
 		return username;
@@ -103,7 +105,7 @@ public abstract class ConnectionAuthorizationHandler {
 	 * Setter for authorization hostname
 	 * {@link org.eclipse.ice.commands.ConnectionAuthorizationHandler#hostname}
 	 * 
-	 * @param
+	 * @param hostname - hostname for this authorization
 	 */
 	public void setHostname(String hostname) {
 		this.hostname = hostname;
@@ -113,29 +115,30 @@ public abstract class ConnectionAuthorizationHandler {
 	 * Setter for authorization hostname
 	 * {@link org.eclipse.ice.commands.ConnectionAuthorizationHandler#username}
 	 * 
-	 * @param
+	 * @param username - username for this authorization
 	 */
 	public void setUsername(String username) {
 		this.username = username;
 	}
 
 	/**
-	 * Setter for {@link org.eclipse.ice.commands.ConnectionAuthorizationHandler#password}
-	 * Please see the associated comment to this member variable before using this function.
-	 * It is highly recommended that after a connection is established, this function is 
-	 * called again to remove the password information from memory. For example:
-	 * ```java
-	 * ConnectionAuthorizationHandler handler = new BasicConnectionAuthorizationHandler();
-	 * handler.setPassword("password".toCharArray());
-	 * // Now establish some connection with the ConnectionManager
-	 * (insert code to establish connection)
-	 * // Now erase the password from memory
-	 * handler.setPassword("".toCharArray());
+	 * Setter for
+	 * {@link org.eclipse.ice.commands.ConnectionAuthorizationHandler#password}
+	 * Please see the associated comment to this member variable before using this
+	 * function. It is highly recommended that after a connection is established,
+	 * this function is called again to remove the password information from memory.
+	 * For example: 
+	 * ```java ConnectionAuthorizationHandler handler = new
+	 * BasicConnectionAuthorizationHandler();
+	 * handler.setPassword("password".toCharArray()); // Now establish some
+	 * connection with the ConnectionManager (insert code to establish connection)
+	 * // Now erase the password from memory handler.setPassword("".toCharArray());
 	 * ```
-	 * @param password
+	 * 
+	 * @param password - password for this authorization
 	 */
 	public void setPassword(char[] password) {
 		this.password = password;
 	}
-	
+
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionAuthorizationHandlerFactory.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionAuthorizationHandlerFactory.java
@@ -34,6 +34,11 @@ public class ConnectionAuthorizationHandlerFactory {
 	 */
 	public final Logger logger = LoggerFactory.getLogger(ConnectionAuthorizationHandlerFactory.class);
 
+	/**
+	 * A hashmap which contains the entire list of possible authorization handlers. All
+	 * child classes of ConnectionAuthorizationHandler are included. Instances of each
+	 * class can be obtained by requesting the particular name key from the hash map.
+	 */
 	private HashMap<String, ConnectionAuthorizationHandler> handlerList = new HashMap<String, ConnectionAuthorizationHandler>();
 
 	/**
@@ -62,8 +67,8 @@ public class ConnectionAuthorizationHandlerFactory {
 	 * and thus can be left as null. Useful when a console or local connection
 	 * authorization handler is desired
 	 * 
-	 * @param type
-	 * @return
+	 * @param type - String corresponding to which handlerList type to get
+	 * @return - The ConnectionAuthorizationHandler requested
 	 */
 	public ConnectionAuthorizationHandler getConnectionAuthorizationHandler(String type) {
 		return getConnectionAuthorizationHandler(type, "");
@@ -73,8 +78,8 @@ public class ConnectionAuthorizationHandlerFactory {
 	 * Factory method to get a particular connection authorization handler. Returns
 	 * a handler to authorize remote connections.
 	 * 
-	 * @param type - type of authorization handler desired
-	 * @return - authorization handler
+	 * @param type - String corresponding to which handlerList type to get
+	 * @return - The ConnectionAuthorizationHandler requested
 	 */
 	public ConnectionAuthorizationHandler getConnectionAuthorizationHandler(String type, String option) {
 		ConnectionAuthorizationHandler auth = null;
@@ -101,8 +106,8 @@ public class ConnectionAuthorizationHandlerFactory {
 	 * the list and then check for it when determining what type of
 	 * ConnectionAuthorizationHandler to return.
 	 * 
-	 * @param type
-	 * @param auth
+	 * @param type - the name for the type of authorization handler
+	 * @param auth - the instance of a new authorization handler to be added to the hashmap
 	 */
 	public void addConnectionAuthorizationHandlerType(String type, ConnectionAuthorizationHandler auth) {
 		handlerList.put(type, auth);

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionConfiguration.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionConfiguration.java
@@ -56,7 +56,7 @@ public class ConnectionConfiguration {
 	 * A getter to access
 	 * {@link org.eclipse.ice.commands.ConnectionConfiguration#name}
 	 * 
-	 * @return - name
+	 * @return - name of the ConnectionConfiguration
 	 */
 	public String getName() {
 		return name;
@@ -66,7 +66,7 @@ public class ConnectionConfiguration {
 	 * A setter to access
 	 * {@link org.eclipse.ice.commands.ConnectionConfiguration#name}
 	 * 
-	 * @return - name
+	 * @return - name of this ConnectionConfiguration
 	 */
 	public void setName(String name) {
 		this.name = name;
@@ -77,7 +77,8 @@ public class ConnectionConfiguration {
 	 * completion
 	 * {@link org.eclipse.ice.commands.ConnectionConfiguration#deleteWorkingDirectory}
 	 * 
-	 * @return
+	 * @return - boolean indicating whether or not remote working direcctory should
+	 *           be deleted upon completion
 	 */
 	public boolean deleteWorkingDirectory() {
 		return deleteWorkingDirectory;
@@ -88,7 +89,8 @@ public class ConnectionConfiguration {
 	 * completion
 	 * {@link org.eclipse.ice.commands.ConnectionConfiguration#deleteWorkingDirectory}
 	 * 
-	 * @param
+	 * @param deleteWorkingDirectory - boolean indicating whether or not remote working 
+	 *                                 directory should be deleted upon completion
 	 */
 	public void deleteWorkingDirectory(boolean deleteWorkingDirectory) {
 		this.deleteWorkingDirectory = deleteWorkingDirectory;
@@ -98,7 +100,7 @@ public class ConnectionConfiguration {
 	 * Setter for the authorization method, if desired. See
 	 * {@link org.eclipse.ice.commands.ConnectionConfiguration#authorization}
 	 * 
-	 * @param authorization
+	 * @param authorization - authorization for this ConnectionConfiguration
 	 */
 	public void setAuthorization(ConnectionAuthorizationHandler authorization) {
 		this.authorization = new AtomicReference<ConnectionAuthorizationHandler>(authorization);
@@ -108,7 +110,7 @@ public class ConnectionConfiguration {
 	 * Getter for the authorization method, if desired. See
 	 * {@link org.eclipse.ice.commands.ConnectionConfiguration#authorization}
 	 * 
-	 * @param authorization
+	 * @param authorization - authorization for this ConnectionConfiguration
 	 */
 	public ConnectionAuthorizationHandler getAuthorization() {
 		return authorization.get();

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManager.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManager.java
@@ -126,7 +126,6 @@ public class ConnectionManager {
 			if (knownHosts != null) {
 				newConnection.getSession().setServerKeyVerifier(new DefaultKnownHostsServerKeyVerifier(delegate,
 						requireStrictHostKeyChecking, Paths.get(knownHosts)));
-				System.out.println("\n\n\n\n\n\nKNOWN HOSTS IS : " + knownHosts);
 			} else {
 				newConnection.getSession().setServerKeyVerifier(
 						new DefaultKnownHostsServerKeyVerifier(delegate, requireStrictHostKeyChecking));

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManagerFactory.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManagerFactory.java
@@ -35,7 +35,7 @@ public class ConnectionManagerFactory {
 	/**
 	 * A function to return the static instance of ConnectionManager
 	 * 
-	 * @return
+	 * @return - static instance of ConnectionManager
 	 */
 	public static ConnectionManager getConnectionManager() {
 		return manager;

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
@@ -55,7 +55,7 @@ public abstract class FileHandler implements IFileHandler {
 	protected CommandStatus transferStatus;
 
 	/**
-	 * An enun to determine what the actual handle type is to set for the command.
+	 * An enum to determine what the actual handle type is to set for the command.
 	 * Default to null so that the RemoteFileHandler tries to determine it on its
 	 * own - however, user can set this explicitly.
 	 */
@@ -189,8 +189,8 @@ public abstract class FileHandler implements IFileHandler {
 	 * Function to determine whether or not a given string is located on the local
 	 * machine
 	 * 
-	 * @param file
-	 * @return
+	 * @return - boolean indicating whether or not the file exists locally (true) 
+	 *           or not (false)
 	 */
 	protected boolean isLocal(String file) {
 		// Get the path
@@ -204,8 +204,8 @@ public abstract class FileHandler implements IFileHandler {
 	 * This operation creates all the directories that are parents of the
 	 * destination.
 	 * 
-	 * @param dest the destination for which parent directories should be created
-	 * @return true if the directories were created
+	 * @param dest - the destination for which parent directories should be created
+	 * @return true if the directories were created, false otherwise
 	 * @throws IOException thrown if the dest cannot be created
 	 */
 	protected boolean createDirectories(String dest) throws IOException {
@@ -231,7 +231,7 @@ public abstract class FileHandler implements IFileHandler {
 	 * 
 	 * @param destination - destination for the file to go to
 	 * @return - CommandStatus indicating whether or not the transfer completed
-	 *         successfully
+	 *           successfully
 	 * @throws IOException
 	 */
 	protected CommandStatus executeTransfer(final String destination) throws IOException {
@@ -251,7 +251,7 @@ public abstract class FileHandler implements IFileHandler {
 	 * A setter to set the type of file handle this is. See
 	 * {@link org.eclipse.ice.commands.RemoteFileHandler#HANDLE_TYPE}
 	 * 
-	 * @param HANDLE_TYPE
+	 * @param HANDLE_TYPE - HandleType for a given transfer
 	 */
 	public void setHandleType(HandleType HANDLE_TYPE) {
 		this.HANDLE_TYPE = HANDLE_TYPE;
@@ -260,7 +260,7 @@ public abstract class FileHandler implements IFileHandler {
 	/**
 	 * Get the connection for this file handler
 	 * 
-	 * @return
+	 * @return - Connection corresponding to this file handler
 	 */
 	public Connection getConnection() {
 		return connection.get();

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandlerFactory.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandlerFactory.java
@@ -69,7 +69,7 @@ public class FileHandlerFactory {
 	 * 
 	 * @param host - String of the hostname to be checked
 	 * @return boolean - returns true if the hostname matches that of the local
-	 *         hostname, false otherwise.
+	 *                   hostname, false otherwise.
 	 */
 	private boolean isLocal(String host) {
 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/IFileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/IFileHandler.java
@@ -27,7 +27,7 @@ public interface IFileHandler {
 	 * path If the operation fails, an exception is thrown
 	 * 
 	 * @return - CommandStatus - a CommandStatus indicating whether or not the move
-	 *         was successful
+	 *           was successful
 	 * @throws IOException
 	 */
 	public abstract CommandStatus move(final String source, final String destination) throws IOException;
@@ -37,7 +37,7 @@ public interface IFileHandler {
 	 * path If the operation fails, an exception is thrown
 	 * 
 	 * @return - CommandStatus - a CommandStatus indicating whether or not the copy
-	 *         was successful
+	 *           was successful
 	 * @throws IOException
 	 */
 	public abstract CommandStatus copy(final String source, final String destination) throws IOException;
@@ -47,9 +47,9 @@ public interface IFileHandler {
 	 * already exists for a given path.
 	 * 
 	 * @param - String - a string with the path for the method to check its
-	 *          existence
+	 *                   existence
 	 * @return - boolean indicating whether or not the file exists (returns true) or
-	 *         does not exist (returns false)
+	 *           does not exist (returns false)
 	 * @throws IOException
 	 */
 	public abstract boolean exists(final String file) throws IOException;
@@ -59,8 +59,8 @@ public interface IFileHandler {
 	 * destination doesn't exist, it tries to make it. If the destination can't be
 	 * made, or the source doesn't exist, the method throws an exception.
 	 * 
-	 * @param source
-	 * @param destination
+	 * @param source - source path to check existence of before file transfer
+	 * @param destination - destination path to check existence of before file transfer
 	 * @throws IOException
 	 */
 	public abstract void checkExistence(final String source, final String destination) throws IOException;
@@ -68,7 +68,7 @@ public interface IFileHandler {
 	/**
 	 * Method that returns a FileBrowser instance
 	 * 
-	 * @return - FileBrowser
+	 * @return - FileBrowser - a FileBrowser instance
 	 * @param  - Directory to browse
 	 */
 	public abstract FileBrowser getFileBrowser(final String topDirectory);

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/KeyPathConnectionAuthorizationHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/KeyPathConnectionAuthorizationHandler.java
@@ -20,6 +20,9 @@ package org.eclipse.ice.commands;
  */
 public class KeyPathConnectionAuthorizationHandler extends ConnectionAuthorizationHandler {
 
+	/**
+	 * A string that holds the path to the key used for a connection authorization
+	 */
 	private String keyPath = null;
 
 	/**
@@ -28,6 +31,11 @@ public class KeyPathConnectionAuthorizationHandler extends ConnectionAuthorizati
 	public KeyPathConnectionAuthorizationHandler() {
 	}
 
+	/**
+	 * Constructor with a given key path
+	 * 
+	 * @param keyPath - String corresponding to the path for the key
+	 */
 	public KeyPathConnectionAuthorizationHandler(String keyPath) {
 		this.keyPath = keyPath;
 	}
@@ -36,7 +44,7 @@ public class KeyPathConnectionAuthorizationHandler extends ConnectionAuthorizati
 	 * Setter for
 	 * {@link org.eclipse.ice.commands.KeyPathConnectionAuthorizationHandler#keyPath}
 	 * 
-	 * @param keyPath
+	 * @param keyPath - String corresponding to the path for the key
 	 */
 	@Override
 	public void setOption(String option) {
@@ -47,11 +55,12 @@ public class KeyPathConnectionAuthorizationHandler extends ConnectionAuthorizati
 	 * Getter for
 	 * {@link org.eclipse.ice.commands.KeyPathConnectionAuthorizationHandler#keyPath}
 	 * 
-	 * @return
+	 * @return - String corresponding to the path for the key
 	 */
 	public String getKeyPath() {
 		return keyPath;
 	}
+
 	/**
 	 * See
 	 * {@link org.eclipse.ice.commands.ConnectionAuthorizationHandler#getPassword()}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
@@ -51,14 +51,16 @@ public class LocalCommand extends Command {
 	 * {@link org.eclipse.ice.commands.LocalCommand#setConfiguration(CommandConfiguration)}
 	 * for details about what details are required.
 	 * 
-	 * @param _configuration
+	 * @param _connection    - ConnectionConfiguration corresponding to a local
+	 *                       connection
+	 * @param _configuration - CommandConfiguration for this particular command
 	 */
-	public LocalCommand(ConnectionConfiguration _connection, CommandConfiguration _configuration) {
+	public LocalCommand(ConnectionConfiguration connectionConfig, CommandConfiguration commandConfig) {
 
 		status = CommandStatus.PROCESSING;
 
 		// Set the configuration for the command
-		commandConfig = _configuration;
+		this.commandConfig = commandConfig;
 
 		// If commandConfig wasn't set properly, the job can't run
 		if (commandConfig == null)
@@ -66,12 +68,12 @@ public class LocalCommand extends Command {
 
 		// Set the connection for the local command, which is only relevant for
 		// accessing the hostname of the local computer
-		connectionConfig = _connection;
+		this.connectionConfig = connectionConfig;
 
 		// Make sure both commandConfig and connectionConfig have the same
 		// hostname, since commandConfig needs the hostname for several output
 		// files (e.g. for debugging purposes).
-		commandConfig.setHostname(connectionConfig.getAuthorization().getHostname());
+		this.commandConfig.setHostname(connectionConfig.getAuthorization().getHostname());
 
 	}
 
@@ -230,9 +232,6 @@ public class LocalCommand extends Command {
 	 * finished successfully according to the ProcessBuilder.
 	 * 
 	 * See also {@link org.eclipse.ice.commands.Command#finishJob()}
-	 * 
-	 * @return - CommandStatus indicating whether or not the function processed
-	 *         correctly
 	 */
 	@Override
 	protected CommandStatus finishJob() {
@@ -310,9 +309,9 @@ public class LocalCommand extends Command {
 		// finishes.
 		while (exitValue != 0) {
 			// First make sure the job hasn't been canceled
-			if(status == CommandStatus.CANCELED)
+			if (status == CommandStatus.CANCELED)
 				return CommandStatus.CANCELED;
-			
+
 			// Try to get the exit value of the job
 			// If the job completed successfully this will be 0
 			try {

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalConnectionAuthorizationHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalConnectionAuthorizationHandler.java
@@ -63,7 +63,7 @@ public class LocalConnectionAuthorizationHandler extends ConnectionAuthorization
 	}
 
 	/**
-	 * No options required for console authorization See
+	 * No options required for console authorization. See
 	 * {@link org.eclipse.ice.commands.ConnectionAuthorizationHandler#setOption(String)}
 	 */
 	@Override

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
@@ -49,7 +49,7 @@ public class LocalCopyFileCommand extends LocalCommand {
 	 * copy was completed successfully. It returns a CommandStatus indicating
 	 * whether or not the move was successful.
 	 * 
-	 * @return CommandStatus
+	 * See also {@link org.eclipse.ice.commands.LocalCommand#execute()}
 	 */
 	@Override
 	public CommandStatus execute() {
@@ -65,7 +65,7 @@ public class LocalCopyFileCommand extends LocalCommand {
 	 * CommandStatus indicating that the command is currently running and needs to
 	 * be checked that it completed correctly.
 	 * 
-	 * @return CommandStatus
+	 * See also {@link org.eclipse.ice.commands.LocalCommand#run()}
 	 */
 	@Override
 	protected CommandStatus run() {
@@ -98,7 +98,7 @@ public class LocalCopyFileCommand extends LocalCommand {
 	/**
 	 * A function that returns the source path in string form
 	 * 
-	 * @return - String
+	 * @return - String of source path
 	 */
 	public String getSource() {
 		return source.toString();
@@ -107,7 +107,7 @@ public class LocalCopyFileCommand extends LocalCommand {
 	/**
 	 * A function that returns the destination path in string form
 	 * 
-	 * @return - String
+	 * @return - String of destination path
 	 */
 	public String getDestination() {
 		return destination.toString();

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalFileBrowser.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalFileBrowser.java
@@ -49,7 +49,9 @@ public class LocalFileBrowser extends SimpleFileVisitor<Path> implements FileBro
 		
 	}
 
-	// Add the file path to fileList
+	/**
+	 * Add the file path to the array list fileList
+	 */
 	@Override
 	public FileVisitResult visitFile(Path file, BasicFileAttributes attr) {
 		// Add the file, depending on it's attribute
@@ -60,7 +62,9 @@ public class LocalFileBrowser extends SimpleFileVisitor<Path> implements FileBro
 		return FileVisitResult.CONTINUE;
 	}
 
-	// Add the directory path to the array list directoryList
+	/** 
+	 * Add the directory path to the array list directoryList
+	 */
 	@Override
 	public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
 		directoryList.add(dir.toString());
@@ -81,7 +85,7 @@ public class LocalFileBrowser extends SimpleFileVisitor<Path> implements FileBro
 	/**
 	 * See {@link org.eclipse.ice.commands.FileBrowser#getFileList()}
 	 * 
-	 * @return
+	 * @return = ArrayList<String> of files
 	 */
 	@Override
 	public ArrayList<String> getFileList() {
@@ -91,7 +95,7 @@ public class LocalFileBrowser extends SimpleFileVisitor<Path> implements FileBro
 	/**
 	 * See {@link org.eclipse.ice.commands.FileBrowser#getDirectoryList()}
 	 * 
-	 * @return
+	 * @return - ArrayList<String> of directories
 	 */
 	@Override
 	public ArrayList<String> getDirectoryList() {
@@ -102,6 +106,8 @@ public class LocalFileBrowser extends SimpleFileVisitor<Path> implements FileBro
 	 * This function performs the action of walking the file tree for the file
 	 * browsing capabilities of LocalFileHandler. It returns a LocalFileWalker so
 	 * that the files or directories could be obtained
+	 * 
+	 * @param topDirectory - top most directory to recursively walk through
 	 * 
 	 */
 	private void walkTree(final String topDirectory) {

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
@@ -49,7 +49,7 @@ public class LocalMoveFileCommand extends LocalCommand {
 	 * move command was completed successfully. It returns a CommandStatus
 	 * indicating whether or not the move was successful.
 	 * 
-	 * @return CommandStatus
+	 * See also {@link org.eclipse.ice.commands.LocalCommand#execute()}
 	 */
 	@Override
 	public CommandStatus execute() {
@@ -63,8 +63,7 @@ public class LocalMoveFileCommand extends LocalCommand {
 	 * CommandStatus indicating that the command is currently running and needs to
 	 * be checked that it completed correctly.
 	 * 
-	 * @return CommandStatus - indicates whether or not the move was successful or
-	 *         not
+	 * See also {@link org.eclipse.ice.commands.LocalCommand#run()}
 	 */
 	@Override
 	protected CommandStatus run() {
@@ -185,7 +184,7 @@ public class LocalMoveFileCommand extends LocalCommand {
 	/**
 	 * A function that returns the source path in string form
 	 * 
-	 * @return - String
+	 * @return - String of the source path
 	 */
 	public String getSource() {
 		return source.toString();
@@ -194,7 +193,7 @@ public class LocalMoveFileCommand extends LocalCommand {
 	/**
 	 * A function that returns the destination path in string form
 	 * 
-	 * @return - String
+	 * @return - String of the destination path
 	 */
 	public String getDestination() {
 		return destination.toString();

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
@@ -1,5 +1,4 @@
-/**
- * /*******************************************************************************
+/*******************************************************************************
  * Copyright (c) 2019- UT-Battelle, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
@@ -17,6 +17,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -124,10 +127,9 @@ public class RemoteCommand extends Command {
 
 			// If there is an extra connection so that we are multi-hopping, then open it
 			// too
-			// TODO - the multi-hop API isn't implemented yet - need to work on it
 			ConnectionConfiguration secondConfig = secondConnection.get().getConfiguration();
 			if (secondConfig != null) {
-				secondConnection.set(manager.openConnection(secondConfig));
+				secondConnection.set(manager.openForwardingConnection(connection.get(),secondConfig));
 				// Set the commandConfig hostname to be the extra connection, since this is
 				// really where the job will run
 				commandConfig.setHostname(secondConnection.get().getConfiguration().getAuthorization().getHostname());
@@ -140,7 +142,8 @@ public class RemoteCommand extends Command {
 			logger.error("Returning info error", e);
 			return;
 		}
-
+		
+		return;
 	}
 
 	/**
@@ -189,8 +192,6 @@ public class RemoteCommand extends Command {
 	 * then disconnects the remote channel to finish up the job processing.
 	 * 
 	 * See also {@link org.eclipse.ice.commands.Command#finishJob()}
-	 * 
-	 * @return CommandStatus
 	 */
 	@Override
 	protected CommandStatus finishJob() {
@@ -377,6 +378,74 @@ public class RemoteCommand extends Command {
 	}
 
 	/**
+	 * This function is responsible for setting up the file transfer logic,
+	 * depending on whether or not this is a regular remote command or a jump host
+	 * command. It is called from run and executes the logic in
+	 * {@link org.eclipse.ice.commands.RemoteCommand#transferFiles(ConnectionConfiguration, String, String)}
+	 * 
+	 * @return - CommandStatus indicating whether or not the transfer(s) were
+	 *         successful
+	 * @throws IOException
+	 * @throws SftpException
+	 * @throws JSchException
+	 */
+	protected CommandStatus transferFiles() throws IOException {
+		/**
+		 * If we have a jump host connection then we need to transfer the files from the
+		 * intermediary host to the local host first, and then transfer them from the
+		 * local host through the forwarded connection. In other words, the file
+		 * transferring goes from (in the case of System A --> System B --> System C
+		 * where B is the jump host and C is the destination host):
+		 * 
+		 * System B --> System A - transfer the files to a local temp directory, System A
+		 * --> System C - transfer the files from the local temp directory through the
+		 * forwarded connection
+		 */
+		// So first we will transfer from the jump host
+		if (secondConnection.get().getConfiguration() != null) {
+			// Create a temporary local directory to move files from the jump host to
+			// the local host
+			Path tempLocalDir = Files.createTempDirectory("tempJumpDir");
+
+			status = transferFiles(connectionConfig, commandConfig.getWorkingDirectory(), tempLocalDir.toString());
+			// Check that this transfer completed successfully before moving to
+			// transfer from A --> C
+			if (!checkStatus(status))
+				return CommandStatus.FAILED;
+			// Set the working directory to be the temporary local directory that
+			// was created, so that the rest of the command operates as normal
+			// from a local host to a remote host with this new temporary directory
+			status = transferFiles(secondConnection.get().getConfiguration(),
+					tempLocalDir.toString() + FileSystems.getDefault().getSeparator(),
+					commandConfig.getRemoteWorkingDirectory());
+
+			// Delete the local temp file once finished moving to the destination host
+			File localTempFile = new File(tempLocalDir.toString());
+			boolean delete = deleteLocalDirectory(localTempFile);
+			if (!delete) {
+				logger.warn("Temporary directory at " + tempLocalDir.toString() + " couldn't be completely deleted.");
+			}
+			/**
+			 * In order for the rest of the code base to use the forwarded connection as the
+			 * job processing connection, we need to set the main connection of the class,
+			 * i.e. {@link org.eclipse.ice.commands.Command#connection} as the forwarded
+			 * connection
+			 */
+			connection = secondConnection;
+
+		} else {
+			// If this is not a jump host case, then just move the files from the local
+			// working directory to the remote host like normal
+			status = transferFiles(connectionConfig, commandConfig.getWorkingDirectory(),
+					commandConfig.getRemoteWorkingDirectory());
+		}
+
+		return status;
+	}
+
+
+	
+	/**
 	 * This function is responsible for transferring the files to the remote host.
 	 * It utilizes the file handling API in this package
 	 * 
@@ -385,12 +454,21 @@ public class RemoteCommand extends Command {
 	 * @throws JSchException
 	 * @throws IOException
 	 */
-	protected CommandStatus transferFiles() throws IOException {
+	protected CommandStatus transferFiles(ConnectionConfiguration config, String sourceDir, String destDir) throws IOException {
 
+		String sourceSep = "/";
+		String destSep = "/";
+
+		// Figure out what the separators are, depending on windows/*nix
+		if(sourceDir.contains("\\"))
+			sourceSep = "\\";
+		if(destDir.contains("\\"))
+			destSep = "\\";
+		
 		// Set up a remote file handler to transfer the files
 		RemoteFileHandler handler = new RemoteFileHandler();
 		// Give the handler the same connection as this command
-		handler.setConnectionConfiguration(connectionConfig);
+		handler.setConnectionConfiguration(config);
 
 		// Get the directories where files live/should go
 		String remoteWorkingDirectory = commandConfig.getRemoteWorkingDirectory();
@@ -405,14 +483,21 @@ public class RemoteCommand extends Command {
 		else if (shortExecName.contains("\\"))
 			shortExecName = shortExecName.substring(shortExecName.lastIndexOf("\\") + 1);
 
+		// Check that the source directory ends with the right separator
+		if(!sourceDir.endsWith(sourceSep))
+			sourceDir += sourceSep;
+		
 		// Do the same for the destination
-		if (!remoteWorkingDirectory.endsWith("/"))
-			remoteWorkingDirectory += "/";
+		if (!destDir.endsWith(destSep))
+			destDir += destSep;
 
 		// Build the source and destination paths
-		String source = workingDirectory + shortExecName;
-		String destination = remoteWorkingDirectory + shortExecName;
+		String source = sourceDir + shortExecName;
+		String destination = destDir + shortExecName;
 
+		logger.info("Trying to transfer " + source + " to " + destination +
+				" over connection " + config.getName());
+		
 		CommandStatus fileTransfer = null;
 		// Check if the source file exists. If the executable is a script, then it will
 		// transfer it to the host. If it is just a command (e.g. ls) then it will skip
@@ -448,11 +533,10 @@ public class RemoteCommand extends Command {
 
 			// Now have the full paths, so transfer the files per the logger messages
 			// Put the inputfile to the remote directory. Use a null object for receiving
-			// notifications about
-			// the progress of the transfer and use 0 to overwrite the files if they exist
-			// there already
-			source = workingDirectory + shortInputName;
-			destination = remoteWorkingDirectory + shortInputName;
+			// notifications about the progress of the transfer and use 0 to overwrite 
+			// the files if they exist there already
+			source = sourceDir + shortInputName;
+			destination = destDir + shortInputName;
 			fileTransfer = handler.copy(source, destination);
 			if (fileTransfer != CommandStatus.SUCCESS) {
 				logger.error("Couldn't transfer " + source + " to remote host!");
@@ -495,6 +579,27 @@ public class RemoteCommand extends Command {
 		sftpChannel.rmdir(path); // delete the parent directory after empty
 	}
 
+	/**
+	 * Recursive function that deletes a local directory and its contents
+	 * 
+	 * @param directory - directory to be deleted
+	 * @return boolean - true if directory was deleted, false otherwise
+	 */
+	private boolean deleteLocalDirectory(File directory) {
+		// Get the file list of the directory
+		File[] contents = directory.listFiles();
+		// If there are files/subdirectories in the directory, recursively iterate over
+		// them to
+		// delete them so that the directory can be deleted
+		if (contents != null) {
+			for (File file : contents) {
+				deleteLocalDirectory(file);
+			}
+		}
+		// Return whether or not the directory was deleted
+		return directory.delete();
+	}
+	
 	/**
 	 * Set a particular connection for a particular RemoteCommand
 	 * 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
@@ -416,7 +416,7 @@ public class RemoteCommand extends Command {
 			// was created, so that the rest of the command operates as normal
 			// from a local host to a remote host with this new temporary directory
 			status = transferFiles(secondConnection.get().getConfiguration(),
-					tempLocalDir.toString() + FileSystems.getDefault().getSeparator(),
+					tempLocalDir.toString(),
 					commandConfig.getRemoteWorkingDirectory());
 
 			// Delete the local temp file once finished moving to the destination host
@@ -469,10 +469,6 @@ public class RemoteCommand extends Command {
 		RemoteFileHandler handler = new RemoteFileHandler();
 		// Give the handler the same connection as this command
 		handler.setConnectionConfiguration(config);
-
-		// Get the directories where files live/should go
-		String remoteWorkingDirectory = commandConfig.getRemoteWorkingDirectory();
-		String workingDirectory = commandConfig.getWorkingDirectory();
 
 		// Get the executable to concatenate
 		String shortExecName = commandConfig.getExecutable();

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCopyFileCommand.java
@@ -88,7 +88,7 @@ public class RemoteCopyFileCommand extends RemoteCommand {
 	/**
 	 * Get the source file string
 	 * 
-	 * @return
+	 * @return - String of the source path
 	 */
 	public String getSource() {
 		return source;
@@ -97,7 +97,7 @@ public class RemoteCopyFileCommand extends RemoteCommand {
 	/**
 	 * Get the destination file string
 	 * 
-	 * @return
+	 * @return - String of the destination path
 	 */
 	public String getDestination() {
 		return destination;
@@ -106,7 +106,7 @@ public class RemoteCopyFileCommand extends RemoteCommand {
 	/**
 	 * Set the copy type variable
 	 * 
-	 * @param type
+	 * @param copyType - HandleType for this file transfer
 	 */
 	public void setCopyType(HandleType copyType) {
 		this.copyType = copyType;
@@ -115,7 +115,7 @@ public class RemoteCopyFileCommand extends RemoteCommand {
 	/**
 	 * Set the permissions for a chmod during file transfer
 	 * 
-	 * @param permissions
+	 * @param permissions - file permissions to be set upon file transfer
 	 */
 	protected void setPermissions(int permissions) {
 		this.permissions = permissions;

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteFileBrowser.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteFileBrowser.java
@@ -25,21 +25,25 @@ import org.apache.sshd.client.subsystem.sftp.SftpClient.DirEntry;
  */
 public class RemoteFileBrowser implements FileBrowser {
 	/**
-	 * Default  constructor
+	 * Default constructor
 	 */
 	public RemoteFileBrowser() {
+		// Clear the arrays to start fresh for every browser
 		fileList.clear();
 		directoryList.clear();
 	}
-	
+
 	/**
 	 * Default constructor with connection and top directory name
+	 * 
+	 * @param connection   - Connection over which to file browse
+	 * @param topDirectory - top most directory to recursively walk through
 	 */
 	public RemoteFileBrowser(Connection connection, final String topDirectory) {
 		// Make sure we start with a fresh list every time the browser is called
 		fileList.clear();
 		directoryList.clear();
-		
+
 		// Fill the arrays with the relevant file information
 		fillArrays(topDirectory, connection.getSftpChannel());
 	}
@@ -49,18 +53,17 @@ public class RemoteFileBrowser implements FileBrowser {
 	 * remote host and fill the member variable arrays with the files and
 	 * directories
 	 * 
-	 * @param channel
-	 * @param topDirectory
+	 * @param channel      - sftp channel to walk the file tree with
+	 * @param topDirectory - top most directory under which to browse
 	 */
 	protected void fillArrays(String topDirectory, SftpClient channel) {
 		try {
 			// Make sure the top directory ends with the appropriate separator
 			String separator = "/";
-			// If the remote file system returns a home directory with \, then it
-			// must be windows
-			// TODO: I don't know how to do this using Mina. Is it really needed anyway?
-//			if (channel.getHome().contains("\\"))
-//				separator = "\\";
+			// If the remote directory to search contains a \\, then it must be windows
+			// and thus we should set the separator as such
+			if (topDirectory.contains("\\"))
+				separator = "\\";
 
 			// Now check the path name
 			if (!topDirectory.endsWith(separator))
@@ -88,8 +91,6 @@ public class RemoteFileBrowser implements FileBrowser {
 
 	/**
 	 * See {@link org.eclipse.ice.commands.FileBrowser#getDirectoryList()}
-	 * 
-	 * @return
 	 */
 	@Override
 	public ArrayList<String> getDirectoryList() {
@@ -98,8 +99,6 @@ public class RemoteFileBrowser implements FileBrowser {
 
 	/**
 	 * See {@link org.eclipse.ice.commands.FileBrowser#getFileList()}
-	 * 
-	 * @return
 	 */
 	@Override
 	public ArrayList<String> getFileList() {

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteFileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteFileHandler.java
@@ -25,8 +25,6 @@ import org.apache.sshd.client.subsystem.sftp.SftpClientFactory;
  *
  */
 
-
-
 public class RemoteFileHandler extends FileHandler {
 
 	/**
@@ -48,7 +46,7 @@ public class RemoteFileHandler extends FileHandler {
 	 * checks if the connection is already open, and if it is not it calls the
 	 * connection manager to open the connection
 	 * 
-	 * @param config
+	 * @param config - ConnectionConfiguration for file transferring
 	 */
 	public void setConnectionConfiguration(ConnectionConfiguration config) {
 		// Get the connection manager and open the connection in constructor so that it
@@ -95,8 +93,7 @@ public class RemoteFileHandler extends FileHandler {
 			if (isLocal(file)) {
 				// If the file can be found locally, return true since we found it.
 				// Up to checkExistence to determine what kind of move this is (e.g.
-				// local->remote
-				// or vice versa)
+				// local->remote or vice versa)
 				return true;
 			} else {
 				return false;
@@ -156,6 +153,9 @@ public class RemoteFileHandler extends FileHandler {
 	 * determines what kind of remote move it is, i.e. which direction the move is
 	 * going (local --> remote, remote --> local, remote --> remote, etc.)
 	 * 
+	 * Alternatively, the move can be set by the client using
+	 * {@link org.eclipse.ice.commands.RemoteFileHandler#setHandleType(HandleType)}
+	 * 
 	 * @throws JSchException
 	 */
 	@Override
@@ -178,19 +178,19 @@ public class RemoteFileHandler extends FileHandler {
 
 		// If the user set the handle type explicitly, check their existence
 		// and return if they are confirmed to exist
-		if(HANDLE_TYPE != null) {
-			if(HANDLE_TYPE == HandleType.localRemote) {
-				if(isLocal(source) && exists(destination))
+		if (HANDLE_TYPE != null) {
+			if (HANDLE_TYPE == HandleType.localRemote) {
+				if (isLocal(source) && exists(destination))
 					return;
 			} else if (HANDLE_TYPE == HandleType.remoteLocal) {
-				if(isLocal(destination) && exists(source))
+				if (isLocal(destination) && exists(source))
 					return;
 			} else {
-				if(exists(destination) && exists(source))
+				if (exists(destination) && exists(source))
 					return;
 			}
 		}
-		
+
 		// Otherwise try and figure out what kind of file transfer is
 		// If the source is local, then try a local --> remote handle
 		if (isLocal(source)) {
@@ -252,8 +252,8 @@ public class RemoteFileHandler extends FileHandler {
 		}
 
 		// Print out the determined handle type for informational purposes
-		logger.info(
-				"FileHandler is moving/copying " + source + " to " + destination + " with the handle type " + HANDLE_TYPE);
+		logger.info("FileHandler is moving/copying " + source + " to " + destination + " with the handle type "
+				+ HANDLE_TYPE);
 
 	}
 
@@ -309,7 +309,8 @@ public class RemoteFileHandler extends FileHandler {
 	 * normal chmod, and changes it to decimal.
 	 * 
 	 * 
-	 * @param permissions
+	 * @param permissions - String of the permissions to set. Taken as a string
+	 * so that it can be converted to decimal from octal
 	 */
 	public void setPermissions(String permissions) {
 		this.permissions = Integer.parseInt(permissions, 8);

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteMoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteMoveFileCommand.java
@@ -89,7 +89,7 @@ public class RemoteMoveFileCommand extends RemoteCommand {
 	/**
 	 * Get the source file string
 	 * 
-	 * @return
+	 * @return - string of the source path
 	 */
 	public String getSource() {
 		return source;
@@ -98,7 +98,7 @@ public class RemoteMoveFileCommand extends RemoteCommand {
 	/**
 	 * Get the destination file string
 	 * 
-	 * @return
+	 * @return - string of the destination path
 	 */
 	public String getDestination() {
 		return destination;
@@ -107,7 +107,7 @@ public class RemoteMoveFileCommand extends RemoteCommand {
 	/**
 	 * Set the move type variable
 	 * 
-	 * @param type
+	 * @param moveType - HandleType for this file transfer
 	 */
 	public void setMoveType(HandleType moveType) {
 		this.moveType = moveType;
@@ -116,7 +116,7 @@ public class RemoteMoveFileCommand extends RemoteCommand {
 	/**
 	 * Set the permissions for a chmod during file transfer
 	 * 
-	 * @param permissions
+	 * @param permissions - file permissions for new file upon transfer
 	 */
 	protected void setPermissions(int permissions) {
 		this.permissions = permissions;

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/TxtFileConnectionAuthorizationHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/TxtFileConnectionAuthorizationHandler.java
@@ -42,14 +42,15 @@ public class TxtFileConnectionAuthorizationHandler extends ConnectionAuthorizati
 	}
 
 	/**
-	 * No options required for console authorization
-	 * See {@link org.eclipse.ice.commands.ConnectionAuthorizationHandler#setOption(String)}
+	 * No options required for console authorization See
+	 * {@link org.eclipse.ice.commands.ConnectionAuthorizationHandler#setOption(String)}
 	 */
 	@Override
 	public void setOption(String option) {
 		this.path = option;
 		setUsernameHostname();
 	}
+
 	/**
 	 * See
 	 * {@link org.eclipse.ice.commands.ConnectionAuthorizationHandler#getPassword()}
@@ -82,14 +83,14 @@ public class TxtFileConnectionAuthorizationHandler extends ConnectionAuthorizati
 		Scanner scanner = null;
 		try {
 			scanner = new Scanner(credFile);
-			
+
 			username = scanner.next();
 			// Get the next line, and then set it to null so that it is picked up by the
 			// garbage collector and erased
 			char[] password = scanner.next().toCharArray();
 			// Erase contents of pwd and fill with null
 			Arrays.fill(password, Character.MIN_VALUE);
-	
+
 			hostname = scanner.next();
 		} catch (FileNotFoundException e) {
 			logger.error("A path was given where the ssh credentials live, but that path doesn't exist!", e);
@@ -101,7 +102,7 @@ public class TxtFileConnectionAuthorizationHandler extends ConnectionAuthorizati
 	 * Getter for
 	 * {@link org.eclipse.ice.commands.TxtFileConnectionAuthorizationHandler#path}
 	 * 
-	 * @return
+	 * @return path - string of path to text file
 	 */
 	public String getPath() {
 		return path;
@@ -111,7 +112,8 @@ public class TxtFileConnectionAuthorizationHandler extends ConnectionAuthorizati
 	 * Setter for
 	 * {@link org.eclipse.ice.commands.TxtFileConnectionAuthorizationHandler#path}
 	 * Also then sets the username and hostname to that defined by the new path
-	 * @param
+	 * 
+	 * @param path - string of path to set
 	 */
 	public void setPath(String path) {
 		this.path = path;

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
@@ -123,7 +123,7 @@ public class CommandFactoryTest {
 		rm += " someLsOutFile.txt someLsErrFile.txt someMultRemoteOutFile.txt someMultRemoteErrFile.txt";
 		rm += " somePythOutFile.txt somePythErrFile.txt someLsRemoteErrFile.txt someLsRemoteOutFile.txt";
 		rm += " src/test/java/org/eclipse/ice/tests/someInputFile.txt src/test/java/org/eclipse/ice/tests/someOtherInputFile.txt";
-		rm += " pythOutFile.txt pythErrFile.txt hopRemoteOutFile.txt hopeRemoteErrFile.txt";
+		rm += " pythOutFile.txt pythErrFile.txt hopRemoteOutFile.txt hopRemoteErrFile.txt";
 		ArrayList<String> command = new ArrayList<String>();
 		// Build a command
 		if (System.getProperty("os.name").toLowerCase().contains("win")) {

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
@@ -178,8 +178,9 @@ public class CommandFactoryTest {
 		ConnectionAuthorizationHandlerFactory authFactory = new ConnectionAuthorizationHandlerFactory();
 		// Request a ConnectionAuthorization of type text file which contains the
 		// credentials
+		String keyPath = System.getProperty("user.home") + "/.ssh/denisovankey";
 		ConnectionAuthorizationHandler auth = authFactory.getConnectionAuthorizationHandler("keypath",
-				"/home/4jo/.ssh/denisovankey");
+				keyPath);
 		auth.setHostname("denisovan");
 		auth.setUsername("4jo");
 		// Set it

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
@@ -178,11 +178,11 @@ public class CommandFactoryTest {
 		ConnectionAuthorizationHandlerFactory authFactory = new ConnectionAuthorizationHandlerFactory();
 		// Request a ConnectionAuthorization of type text file which contains the
 		// credentials
-		String keyPath = System.getProperty("user.home") + "/.ssh/denisovankey";
+		String keyPath = System.getProperty("user.home") + "/.ssh/somekey";
 		ConnectionAuthorizationHandler auth = authFactory.getConnectionAuthorizationHandler("keypath",
 				keyPath);
-		auth.setHostname("denisovan");
-		auth.setUsername("4jo");
+		auth.setHostname("hostname");
+		auth.setUsername("password");
 		// Set it
 		ConnectionConfiguration firstConn = new ConnectionConfiguration();
 		firstConn.setAuthorization(auth);

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
@@ -123,7 +123,7 @@ public class CommandFactoryTest {
 		rm += " someLsOutFile.txt someLsErrFile.txt someMultRemoteOutFile.txt someMultRemoteErrFile.txt";
 		rm += " somePythOutFile.txt somePythErrFile.txt someLsRemoteErrFile.txt someLsRemoteOutFile.txt";
 		rm += " src/test/java/org/eclipse/ice/tests/someInputFile.txt src/test/java/org/eclipse/ice/tests/someOtherInputFile.txt";
-		rm += " pythOutFile.txt pythErrFile.txt";
+		rm += " pythOutFile.txt pythErrFile.txt hopRemoteOutFile.txt hopeRemoteErrFile.txt";
 		ArrayList<String> command = new ArrayList<String>();
 		// Build a command
 		if (System.getProperty("os.name").toLowerCase().contains("win")) {
@@ -151,25 +151,26 @@ public class CommandFactoryTest {
 
 	/**
 	 * This function tests a multi-hop remote command, where the command logs into a
-	 * remote host and then executes on a different remote host. TODO - Commented
-	 * out for now since multi-hop command source code is not implemented and can be
-	 * for future development.
+	 * remote host and then executes on a different remote host. 
 	 */
-	// @Test
+	@Test
 	public void testMultiHopRemoteCommand() {
-		fail("src not implemented");
 		System.out.println("\n\n\nTesting a multi-hop remote command");
 		// Set the CommandConfiguration class
 		CommandConfiguration commandConfig = setupDefaultCommandConfig();
 		commandConfig.setExecutable("./test_code_execution.sh");
 		commandConfig.addInputFile("someInputFile", "someInputFile.txt");
+		commandConfig.addInputFile("someOtherFile", "someOtherInputFile.txt");
 		commandConfig.setAppendInput(true);
 		commandConfig.setCommandId(99);
 		commandConfig.setErrFileName("hopRemoteErrFile.txt");
 		commandConfig.setOutFileName("hopRemoteOutFile.txt");
+		// This is the directory to run the job on the destination system, i.e.
+		// system C
 		commandConfig.setRemoteWorkingDirectory("/tmp/remoteCommandTestDirectory");
-		// Just put in a dummy directory for now
-		commandConfig.setWorkingDirectory("/home/user/somedirectory");
+		// This is the directory on the jump host which contains the job information
+				// and files, e.g. the script, input files, etc.
+		commandConfig.setWorkingDirectory("/home/4jo/remoteCommandDirectory");
 
 		// Set the connection configuration to a dummy remote connection
 		// This is the connection where the job will be executed
@@ -177,26 +178,33 @@ public class CommandFactoryTest {
 		ConnectionAuthorizationHandlerFactory authFactory = new ConnectionAuthorizationHandlerFactory();
 		// Request a ConnectionAuthorization of type text file which contains the
 		// credentials
-		ConnectionAuthorizationHandler auth = authFactory.getConnectionAuthorizationHandler("text",
-				"/tmp/ice-remote-creds.txt");
+		ConnectionAuthorizationHandler auth = authFactory.getConnectionAuthorizationHandler("keypath",
+				"/home/4jo/.ssh/denisovankey");
+		auth.setHostname("denisovan");
+		auth.setUsername("4jo");
 		// Set it
-		connectionConfig.setAuthorization(auth);
+		ConnectionConfiguration firstConn = new ConnectionConfiguration();
+		firstConn.setAuthorization(auth);
 
 		// Note the password can be input at the console by not setting the
 		// the password explicitly in the connection configuration
-		connectionConfig.setName("executeConnection");
-		connectionConfig.deleteWorkingDirectory(true);
+		firstConn.setName("hopConnection");
+		firstConn.deleteWorkingDirectory(false);
 
-		ConnectionConfiguration intermConnection = new ConnectionConfiguration();
-		// TODO - this will have to be changed to some other remote connection
-		intermConnection.setAuthorization(auth);
-		intermConnection.setName("intermediateConnection");
-		intermConnection.deleteWorkingDirectory(false);
+		ConnectionConfiguration secondConn = new ConnectionConfiguration();
+		String credFile = "/tmp/ice-remote-creds.txt";
+		if(System.getProperty("os.name").toLowerCase().contains("win"))
+			credFile = "C:\\Users\\Administrator\\ice-remote-creds.txt";
+		
+		ConnectionAuthorizationHandler intermAuth = authFactory.getConnectionAuthorizationHandler("text",credFile);
+		secondConn.setAuthorization(intermAuth);
+		secondConn.setName("executeConnection");
+		secondConn.deleteWorkingDirectory(false);
 
 		// Get the command
 		Command remoteCommand = null;
 		try {
-			remoteCommand = factory.getCommand(commandConfig, intermConnection, connectionConfig);
+			remoteCommand = factory.getCommand(commandConfig, firstConn, secondConn);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionManagerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionManagerTest.java
@@ -85,21 +85,22 @@ public class ConnectionManagerTest {
 	}
 
 	/**
-	 * Clear out the connections formed after each test so that each test starts fresh
-	 * with a clean slated connection manager
+	 * Clear out the connections formed after each test so that each test starts
+	 * fresh with a clean slated connection manager
+	 * 
 	 * @throws Exception
 	 */
 	@After
 	public void tearDown() throws Exception {
 		// Clear out the connection manager so we start fresh with each test
 		ConnectionManagerFactory.getConnectionManager().removeAllConnections();
-		// Reset the known hosts directory, for after the test with the 
+		// Reset the known hosts directory, for after the test with the
 		// expected JSch exception due to nonexistent known_hosts
 		ConnectionManagerFactory.getConnectionManager()
-		.setKnownHosts(System.getProperty("user.home") + "/.ssh/known_hosts");
+				.setKnownHosts(System.getProperty("user.home") + "/.ssh/known_hosts");
 
-		
 	}
+
 	/**
 	 * This function deletes all of the connections in the connection manager once
 	 * the tests have run and completed.
@@ -117,19 +118,19 @@ public class ConnectionManagerTest {
 
 		// Make sure the known hosts are reset to the default directory
 		manager.setKnownHosts(System.getProperty("user.home") + "/.ssh/known_hosts");
-	
+
 	}
-	
-	
+
 	/**
 	 * This function tests opening a connection with an already generated key path
-	 * @throws JSchException 
+	 * 
+	 * @throws JSchException
 	 */
 	@Test
 	public void testOpenConnectionKeyPath() throws IOException {
 		ConnectionManager manager = ConnectionManagerFactory.getConnectionManager();
 		System.out.println("Testing keypath open connection");
-		
+
 		// Make a connection configuration for using a key path
 		ConnectionConfiguration keyConfiguration = new ConnectionConfiguration();
 		keyConfiguration.setName("keypath");
@@ -144,16 +145,15 @@ public class ConnectionManagerTest {
 		keyConfiguration.setAuthorization(auth);
 		// Open the connection
 		manager.openConnection(keyConfiguration);
-	
+
 		// assert that it was properly opened
-		assert(manager.isConnectionOpen("keypath"));
+		assert (manager.isConnectionOpen("keypath"));
 
 		ConnectionManagerFactory.getConnectionManager()
-				.setKnownHosts(System.getProperty("user.home") + "/.ssh/known_hosts");
+		.setKnownHosts(System.getProperty("user.home") + "/.ssh/known_hosts");
 
 	}
 
-	
 	/**
 	 * Test method for
 	 * {@link org.eclipse.ice.commands.ConnectionManager#OpenConnection(ConnectionConfiguration)}
@@ -215,7 +215,7 @@ public class ConnectionManagerTest {
 	public void testMultipleConnections() {
 
 		ConnectionManager manager = ConnectionManagerFactory.getConnectionManager();
-	
+
 		// Read in a dummy configuration file that contains credentials
 		String credFile = "/tmp/ice-remote-creds.txt";
 		if (System.getProperty("os.name").toLowerCase().contains("win"))
@@ -253,7 +253,7 @@ public class ConnectionManagerTest {
 
 		// Expect only two connections since one of the connections is not good (i.e.
 		// conn3 has a bad password, therefore it isn't added to the list)
-		
+
 		assertEquals(2, connections.size());
 
 		// List all available connections to the console screen
@@ -283,7 +283,7 @@ public class ConnectionManagerTest {
 	@Test
 	public void testValidConnection() {
 		System.out.println("Testing valid connection");
-		
+
 		testOpenConnection();
 
 		testGetConnection();
@@ -309,7 +309,51 @@ public class ConnectionManagerTest {
 
 	}
 
+	/**
+	 * This tests the method openForwardingConnection, which creates a connection
+	 * between three systems by porting the connection through an intermediary host
+	 * @throws IOException 
+	 */
+	@Test
+	public void testForwardConnection() throws IOException {
+		
+		ConnectionManager manager = ConnectionManagerFactory.getConnectionManager();
 
-	
-	
+		// Read in a dummy configuration file that contains credentials
+		String credFile = "/tmp/ice-remote-creds.txt";
+		if (System.getProperty("os.name").toLowerCase().contains("win"))
+			credFile = "C:\\Users\\Administrator\\ice-remote-creds.txt";
+
+		ConnectionAuthorizationHandlerFactory authFactory = new ConnectionAuthorizationHandlerFactory();
+		// Request a ConnectionAuthorization of type text file which contains the
+		// credentials
+		String keyPath = System.getProperty("user.home") + "/.ssh/denisovankey";
+		ConnectionAuthorizationHandler auth = authFactory.getConnectionAuthorizationHandler("keypath",
+				keyPath);
+		auth.setHostname("denisovan");
+		auth.setUsername("4jo");
+		ConnectionConfiguration config = new ConnectionConfiguration();
+		config.setAuthorization(auth);
+		config.setName("forwardConnection");
+		Connection firstConnection = manager.openConnection(config);
+		
+		// Make sure the connection was opened properly
+		assert (manager.isConnectionOpen(firstConnection.getConfiguration().getName()));
+		
+		// Now get the final host authorization
+		ConnectionAuthorizationHandler intermauth = authFactory.getConnectionAuthorizationHandler("text",
+				credFile);
+
+		// Setup the configuration
+		ConnectionConfiguration secondConn = new ConnectionConfiguration();
+		secondConn.setAuthorization(intermauth);
+		secondConn.setName("executeConnection");
+		secondConn.deleteWorkingDirectory(false);
+		System.out.println("\n\n\n\nOpening forwarding connection");
+		// Try to open it
+		Connection forwardConnection = manager.openForwardingConnection(firstConnection, secondConn);
+
+		// Assert that it is open
+		assert(manager.isConnectionOpen(forwardConnection.getConfiguration().getName()));
+	}
 }

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionManagerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionManagerTest.java
@@ -327,11 +327,11 @@ public class ConnectionManagerTest {
 		ConnectionAuthorizationHandlerFactory authFactory = new ConnectionAuthorizationHandlerFactory();
 		// Request a ConnectionAuthorization of type text file which contains the
 		// credentials
-		String keyPath = System.getProperty("user.home") + "/.ssh/denisovankey";
+		String keyPath = System.getProperty("user.home") + "/.ssh/somekey";
 		ConnectionAuthorizationHandler auth = authFactory.getConnectionAuthorizationHandler("keypath",
 				keyPath);
-		auth.setHostname("denisovan");
-		auth.setUsername("4jo");
+		auth.setHostname("hostname");
+		auth.setUsername("password");
 		ConnectionConfiguration config = new ConnectionConfiguration();
 		config.setAuthorization(auth);
 		config.setName("forwardConnection");


### PR DESCRIPTION
# Summary
This PR introduces the possibility to execute commands over a jump connection, where a user connects to a remote host and then runs a job from that remote host to an alternative remote host. This idea was first introduced in a comment from an earlier [PR 411](https://github.com/eclipse/ice/pull/411). Some design changes were implemented to the code so that RemoteCommand could process both single commands and jump connection commands. In the following discussion, let's assume a situation as follows:

System A (local) ---> System B (jump connection) ---> System C (final remote destination)

Here, the job is being executed from System A, the job files (e.g. scripts, input files, etc) exist on System B, and the job should be run on System C.

The major changes implemented are in transferFiles() in RemoteCommand and a new function in ConnectionManager which allows Connections to be opened via a forwarded port. Tests are implemented and need to be automated once an additional dummy server is created.

Note that many files were changed as I did a sweep of the code and added comments where they were lacking.

## Overview of design

The jump connection commands works with the following design.
### Forwarded Connections

A forwarding connection is established with the jump host that operates from the local host through the jump host to the final remote host. This is performed since it is assumed that login credentials to the final host are not available on the local host (otherwise the job could just be run as a normal command). The forwarding operates through a random port on the host connection, assigned while connecting, to an assumed port 22 on the final remote host. This connection is then used to execute the command and connects the jump host through the local host to the final remote host.

### Command Logic

Mina does not allow commands to be executed from the jump host to the final remote host (e.g. from System B to System C in the example). Therefore, the jump commands implementation downloads the necessary files from the jump host to the local host (System B to System A). Then, these files are transferred through the forwarded connection from System A directly to System C. This simplifies the implementation in RemoteCommand anyway since the only function that needs to be modified is transferFiles, after which the execution of the Command can be treated as a normal RemoteCommand between System A and System C utilizing the forwarding connection. The files are copied from the jump host to the local host in a temporary folder on the local host, which is deleted after the files are copied across the forwarded connection.