### PR TITLE
Remote-Remote File Transfer

### DIFF
--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
@@ -188,8 +188,7 @@ public abstract class Command {
 
 		// Check the info and return failure if something was not set
 		if (commandConfig.getExecutable() == null || commandConfig.getOutFileName() == null
-				|| commandConfig.getErrFileName() == null || commandConfig.getNumProcs() == null
-				|| commandConfig.getWorkingDirectory() == null) {
+				|| commandConfig.getErrFileName() == null || commandConfig.getNumProcs() == null) {
 			logger.error("An important piece of information is missing from the CommandConfiguration. Exiting.");
 			return CommandStatus.INFOERROR;
 		}
@@ -202,33 +201,36 @@ public abstract class Command {
 		String separator = "/";
 		if (commandConfig.getOS().toLowerCase().contains("win"))
 			separator = "\\";
-
+		
 		// Check if the working directory exists
 		String workingDir = commandConfig.getWorkingDirectory();
+		boolean exists = false, execExists = false;
+		if(workingDir != null) {
 		if (!workingDir.endsWith(separator))
 			workingDir += separator;
 
 		// Check that the directory exists
 		// Get the file handler factory
 		FileHandlerFactory factory = new FileHandlerFactory();
-		boolean exists = false, execExists = false;
+		
 		try {
 			// Get the handler for this particular connection, whether local or remote
 			FileHandler handler = factory.getFileHandler(connectionConfig);
 
 			// If the working directory was set, check that it exists. If it wasn't set,
 			// then the paths should have been explicitly identified
-			if (workingDir != null)
+		
 				exists = handler.exists(workingDir);
 
-			// Check if the executable exists in the working directory
-			execExists = handler.exists(workingDir + exec);
-
+				// Check if the executable exists in the working directory
+				execExists = handler.exists(workingDir + exec);
+			
 		} catch (IOException e) {
 			// If we can't get the file handler, then there was an error in the connection
 			// configuration
 			logger.error("Unable to connect to filehandler and check file existence. Exiting.", e);
 			return CommandStatus.INFOERROR;
+		}
 		}
 		// If the working directory doesn't exist, we won't be able to continue the job
 		// processing unless the full paths were specified. Warn the user

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
@@ -188,7 +188,8 @@ public abstract class Command {
 
 		// Check the info and return failure if something was not set
 		if (commandConfig.getExecutable() == null || commandConfig.getOutFileName() == null
-				|| commandConfig.getErrFileName() == null || commandConfig.getNumProcs() == null) {
+				|| commandConfig.getErrFileName() == null || commandConfig.getNumProcs() == null
+				|| commandConfig.getWorkingDirectory() == null) {
 			logger.error("An important piece of information is missing from the CommandConfiguration. Exiting.");
 			return CommandStatus.INFOERROR;
 		}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
@@ -62,6 +62,11 @@ public abstract class FileHandler implements IFileHandler {
 	protected HandleType HANDLE_TYPE = null;
 
 	/**
+	 * The source file name
+	 */
+	protected String filename = "";
+	
+	/**
 	 * Have a connection manager for commands that defaults to the static object
 	 * from the factory method. Users can override this if they want to through a
 	 * specific constructor which sets the manager.
@@ -81,7 +86,9 @@ public abstract class FileHandler implements IFileHandler {
 	public CommandStatus move(final String source, final String destination) {
 		// Set the transfer status to processing, to indicate the transfer is beginning
 		transferStatus = CommandStatus.PROCESSING;
-
+		
+		getFileName(source);
+		
 		// Check the file existence. If they don't exist, an exception is thrown
 		try {
 			checkExistence(source, destination);
@@ -100,7 +107,7 @@ public abstract class FileHandler implements IFileHandler {
 			logger.error("Destination file does not exist! File transfer failed!", e);
 			return CommandStatus.FAILED;
 		}
-
+	
 		// Return whether or not it succeeded
 		return transferStatus;
 	}
@@ -113,6 +120,8 @@ public abstract class FileHandler implements IFileHandler {
 		// Set the transfer status to processing, to indicate the transfer is beginning
 		transferStatus = CommandStatus.PROCESSING;
 
+		getFileName(source);
+		
 		// Check the file existence. If one or both don't exist, an exception is thrown
 		try {
 			checkExistence(source, destination);
@@ -131,7 +140,7 @@ public abstract class FileHandler implements IFileHandler {
 			logger.error("Destination file does not exist! File transfer failed!", e);
 			return CommandStatus.FAILED;
 		}
-
+		
 		// Return whether or not it succeeded
 		return transferStatus;
 	}
@@ -238,8 +247,17 @@ public abstract class FileHandler implements IFileHandler {
 		// Execute the file transfer
 		transferStatus = command.get().execute();
 
+		String separator = "/";
+		if(destination.contains("\\"))
+			separator = "\\";
+		
+		String totalDestination = destination;
+		// If the destination is just a path and not a path + filename, add the filename
+		if(destination.endsWith(separator))
+			totalDestination += filename;
+		
 		// Check that the move succeeded
-		if (!exists(destination))
+		if (!exists(totalDestination))
 			return CommandStatus.FAILED;
 
 		logger.info("File transfer successful!");
@@ -275,4 +293,12 @@ public abstract class FileHandler implements IFileHandler {
 		this.connection.set(connection);
 	}
 
+	
+	private void getFileName(String source) {
+		String separator = "/";
+		if(source.contains("\\"))
+			separator = "\\";
+		
+		filename = source.substring(source.lastIndexOf(separator) + 1);
+	}
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandlerFactory.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandlerFactory.java
@@ -40,12 +40,26 @@ public class FileHandlerFactory {
 	}
 
 	/**
+	 * A helper function for file handles that don't require more than one
+	 * connection, i.e. all file handles that are not from one remote host B to
+	 * another remote host C
+	 * 
+	 * @param connectionConfig
+	 * @return
+	 * @throws IOException
+	 */
+	public FileHandler getFileHandler(ConnectionConfiguration connectionConfig) throws IOException {
+		return getFileHandler(connectionConfig, null);
+	}
+
+	/**
 	 * Method which gets a FileHandler and subsequently executes it to initiate a
 	 * file transfer.
 	 * 
 	 * @return FileHandler - instance of FileHandler that does the transfer
 	 */
-	public FileHandler getFileHandler(ConnectionConfiguration connectionConfig) throws IOException {
+	public FileHandler getFileHandler(ConnectionConfiguration connectionConfig,
+			KeyPathConnectionAuthorizationHandler remoteHostC) throws IOException {
 		FileHandler handler = null;
 
 		// Determine if the hostname in the config is local or not
@@ -55,9 +69,19 @@ public class FileHandlerFactory {
 		if (isLocal) {
 			handler = new LocalFileHandler();
 		} else {
-			RemoteFileHandler remoteHandler = new RemoteFileHandler();
-			remoteHandler.setConnectionConfiguration(connectionConfig);
-			handler = remoteHandler;
+			// If the remoteHostC is null then it is a local->remote (or vice versa)
+			// transfer
+			if (remoteHostC == null) {
+				RemoteFileHandler remoteHandler = new RemoteFileHandler();
+				remoteHandler.setConnectionConfiguration(connectionConfig);
+				handler = remoteHandler;
+			} else {
+				// otherwise it is a remote host B to remote host C transfer
+				RemoteRemoteFileHandler remoteHandler = new RemoteRemoteFileHandler();
+				remoteHandler.setConnectionConfiguration(connectionConfig);
+				remoteHandler.setDestinationAuthorization(remoteHostC);
+				handler = remoteHandler;
+			}
 		}
 
 		return handler;
@@ -69,7 +93,7 @@ public class FileHandlerFactory {
 	 * 
 	 * @param host - String of the hostname to be checked
 	 * @return boolean - returns true if the hostname matches that of the local
-	 *                   hostname, false otherwise.
+	 *         hostname, false otherwise.
 	 */
 	private boolean isLocal(String host) {
 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/HandleType.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/HandleType.java
@@ -18,11 +18,12 @@ package org.eclipse.ice.commands;
  * localRemote - local source, remote destination 
  * remoteLocal - remote source, local destination
  * remoteRemote - remote source, remote destination
+ * remoteOtherRemote - remote source on host B, remote destination on host C
  * 
  * @author Joe Osborn
  *
  */
 
 public enum HandleType {
-	localRemote, remoteLocal, remoteRemote;
+	localRemote, remoteLocal, remoteRemote, remoteOtherRemote;
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
@@ -45,7 +45,7 @@ public class RemoteCommand extends Command {
 	 * The particular connection associated to a particular RemoteCommand. Declare
 	 * this up front since by definition a RemoteCommand must have a connection.
 	 */
-	private AtomicReference<Connection> connection = new AtomicReference<Connection>(new Connection());
+	protected AtomicReference<Connection> connection = new AtomicReference<Connection>(new Connection());
 
 	/**
 	 * An additional connection that is used for multi-hop connections, where a user

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
@@ -219,7 +219,8 @@ public class RemoteCommand extends Command {
 			logger.error(e.getLocalizedMessage());
 		}
 		try {
-			connection.get().getSftpChannel().close();
+			if(connection.get().getSftpChannel() != null)
+				connection.get().getSftpChannel().close();
 		} catch (IOException e) {
 			logger.error(e.getLocalizedMessage());
 		}
@@ -442,8 +443,11 @@ public class RemoteCommand extends Command {
 		} else {
 			// If this is not a jump host case, then just move the files from the local
 			// working directory to the remote host like normal
-			status = transferFiles(connectionConfig, commandConfig.getWorkingDirectory(),
-					commandConfig.getRemoteWorkingDirectory());
+			// Only do it if there are files to transfer
+			if(commandConfig.getWorkingDirectory() != null) {
+				status = transferFiles(connectionConfig, commandConfig.getWorkingDirectory(),
+						commandConfig.getRemoteWorkingDirectory());
+			}
 		}
 
 		return status;

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteFileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteFileHandler.java
@@ -65,6 +65,7 @@ public class RemoteFileHandler extends FileHandler {
 		} else {
 			// Get the connection if it is already available
 			connection.set(manager.getConnection(config.getName()));
+			logger.info("Got connection");
 		}
 		// Open an sftp channel for this remote file handler to use
 		try {

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileHandler.java
@@ -1,0 +1,201 @@
+/**
+ * 
+ */
+package org.eclipse.ice.commands;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.sshd.client.subsystem.sftp.SftpClient;
+import org.apache.sshd.client.subsystem.sftp.SftpClientFactory;
+
+/**
+ * This class implements the FileHandler class and contains the logic for
+ * handling files across multiple remote connections, i.e. scp-ing files from
+ * one remote host B to another remote host C from a local host A where the
+ * Commands API is running
+ * 
+ * @author Joe Osborn
+ *
+ */
+public class RemoteRemoteFileHandler extends RemoteFileHandler {
+
+	/**
+	 * A keypath authorization for connecting remote host B to remote host C.
+	 */
+	private KeyPathConnectionAuthorizationHandler remoteHostC = null;
+
+	/**
+	 * A string to  contain the directory of the destination, if the destination was
+	 * given as /path/to/dir/newFilename.whatever
+	 */
+	private String destinationDir = "";
+	
+	/**
+	 * Default constructor
+	 */
+	public RemoteRemoteFileHandler() {
+		// Create a new instance of the remote remote file transfer command for file
+		// existence checks
+
+		HANDLE_TYPE = HandleType.remoteOtherRemote;
+	}
+
+	@Override
+	protected void configureMoveCommand(String source, String destination) {
+		RemoteRemoteFileTransferCommand cmd = new RemoteRemoteFileTransferCommand();
+		cmd.setRemoteHostCAuthorization(remoteHostC);
+		cmd.setConfiguration(source, destination);
+		cmd.setConnectionConfiguration(connection.get().getConfiguration());
+		cmd.setConnection(connection.get());
+		// Create the command config to be run
+		cmd.createCommand();
+		command.set(cmd);
+	}
+
+	@Override
+	protected void configureCopyCommand(String source, String destination) {
+		// copy and move are the same across remote hosts, i.e. scp
+		configureMoveCommand(source, destination);
+
+	}
+
+	/**
+	 * See {@link org.eclipse.ice.commands.FileHandler#exists(String)}. This
+	 * implementation checks if the file exists on the destination remote host C
+	 * only
+	 */
+	@Override
+	public boolean exists(String file) {
+		try {
+			destinationExists(file);
+		} catch (IOException e) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * See
+	 * {@link org.eclipse.ice.commands.FileHandler#checkExistence(String, String)}
+	 */
+	@Override
+	public void checkExistence(String source, String destination) throws IOException {
+		
+		
+		
+		destinationExists(destination);
+
+		sourceExists(source);
+
+		logger.info("FileHandler is moving/copying " + source + " on host "
+				+ connection.get().getConfiguration().getName() + " to " + destination + " on host "
+				+ remoteHostC.getHostname() + " with handle type " + HANDLE_TYPE);
+
+	}
+
+	/**
+	 * Helper function to check if the destination directory exists on remote host C
+	 * 
+	 * @param file
+	 * @return
+	 * @throws IOException
+	 */
+	private void destinationExists(String file) throws IOException {
+		// Run a command that checks whether or not the directory exists
+		// Need to first check and see if it is a directory
+		
+		// Create an ls command
+		String command = "ssh -i " + remoteHostC.getKeyPath() + " " + remoteHostC.getUsername() + "@"
+				+ remoteHostC.getHostname();
+		command += " \"ls " + file + "\"";
+
+		CommandConfiguration config = new CommandConfiguration();
+		config.setExecutable(command);
+		config.setAppendInput(false);
+		config.setCommandId(9999);
+		config.setErrFileName("lsErr.txt");
+		config.setOutFileName("lsOut.txt");
+		config.setNumProcs("1");
+		config.setWorkingDirectory("/notimportant");
+
+		CommandFactory factory = new CommandFactory();
+		Command lsCommand = factory.getCommand(config, connection.get().getConfiguration());
+		CommandStatus lsStatus = lsCommand.execute();
+
+		// If the command was successful, it means that it could successfully ls
+		// indicating that the file was there.
+		if (!lsStatus.equals(CommandStatus.SUCCESS)) {
+			logger.error(
+					"Could not confirm remote host C directory exists. Exiting. Check lsErr or lsOut .txt files for more information.");
+			throw new IOException();
+		}
+
+		// Delete the lsErr and lsOut files that were made
+		String rm = "lsOut.txt lsErr.txt";
+
+		List<String> cmd = new ArrayList<String>();
+		// Build a command
+		if (System.getProperty("os.name").toLowerCase().contains("win")) {
+			cmd.add("powershell.exe");
+		} else {
+			cmd.add("/bin/bash");
+			cmd.add("-c");
+		}
+		cmd.add("rm " + rm);
+
+		// Execute the command with the process builder api
+		ProcessBuilder builder = new ProcessBuilder(cmd);
+		// Files exist in the top most directory of the package
+		String topDir = System.getProperty("user.dir");
+		File filer = new File(topDir);
+		builder.directory(filer);
+		// Process it
+		Process job = builder.start();
+		try {
+			// wait for it to finish
+			job.waitFor();
+		} catch (InterruptedException e) {
+			logger.warn(
+					"Existence output files couldn't be deleted - you can delete them yourself as they are extraneous.");
+			logger.warn("The files are lsErr.txt and lsOut.txt, in your pwd.");
+		}
+
+		return;
+	}
+
+	/**
+	 * Helper function to check if the source file exists on remote host B
+	 * 
+	 * @param file
+	 * @return
+	 * @throws IOException
+	 */
+	private void sourceExists(String file) throws IOException {
+		SftpClient channel = connection.get().getSftpChannel();
+		// try to ls the file on the remote host B
+		// if an exception is caught, it isn't there
+		try {
+			channel.lstat(file);
+		} catch (IOException e) {
+			logger.error("Source file on remote host B does not exist. Exiting.");
+			throw new IOException();
+		}
+		return;
+	}
+
+	
+	/**
+	 * Setter for the keypath information to connect remote host b to remote host c
+	 * 
+	 * @param key
+	 */
+	public void setDestinationAuthorization(KeyPathConnectionAuthorizationHandler remoteHostC) {
+		this.remoteHostC = remoteHostC;
+	}
+
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileHandler.java
@@ -1,16 +1,22 @@
-/**
- * 
- */
+/*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
 package org.eclipse.ice.commands;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.sshd.client.subsystem.sftp.SftpClient;
-import org.apache.sshd.client.subsystem.sftp.SftpClientFactory;
 
 /**
  * This class implements the FileHandler class and contains the logic for
@@ -29,21 +35,19 @@ public class RemoteRemoteFileHandler extends RemoteFileHandler {
 	private KeyPathConnectionAuthorizationHandler remoteHostC = null;
 
 	/**
-	 * A string to  contain the directory of the destination, if the destination was
-	 * given as /path/to/dir/newFilename.whatever
-	 */
-	private String destinationDir = "";
-	
-	/**
 	 * Default constructor
 	 */
 	public RemoteRemoteFileHandler() {
 		// Create a new instance of the remote remote file transfer command for file
 		// existence checks
-
+		// HandleType is always the same for this type of move
 		HANDLE_TYPE = HandleType.remoteOtherRemote;
 	}
 
+	/**
+	 * See
+	 * {@link org.eclipse.ice.commands.FileHandler#configureMoveCommand(String, String)}
+	 */
 	@Override
 	protected void configureMoveCommand(String source, String destination) {
 		RemoteRemoteFileTransferCommand cmd = new RemoteRemoteFileTransferCommand();
@@ -56,6 +60,10 @@ public class RemoteRemoteFileHandler extends RemoteFileHandler {
 		command.set(cmd);
 	}
 
+	/**
+	 * See
+	 * {@link org.eclipse.ice.commands.FileHandler#configureCopyCommand(String, String)}
+	 */
 	@Override
 	protected void configureCopyCommand(String source, String destination) {
 		// copy and move are the same across remote hosts, i.e. scp
@@ -85,9 +93,7 @@ public class RemoteRemoteFileHandler extends RemoteFileHandler {
 	 */
 	@Override
 	public void checkExistence(String source, String destination) throws IOException {
-		
-		
-		
+
 		destinationExists(destination);
 
 		sourceExists(source);
@@ -108,7 +114,6 @@ public class RemoteRemoteFileHandler extends RemoteFileHandler {
 	private void destinationExists(String file) throws IOException {
 		// Run a command that checks whether or not the directory exists
 		// Need to first check and see if it is a directory
-		
 		// Create an ls command
 		String command = "ssh -i " + remoteHostC.getKeyPath() + " " + remoteHostC.getUsername() + "@"
 				+ remoteHostC.getHostname();
@@ -187,7 +192,6 @@ public class RemoteRemoteFileHandler extends RemoteFileHandler {
 		return;
 	}
 
-	
 	/**
 	 * Setter for the keypath information to connect remote host b to remote host c
 	 * 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileHandler.java
@@ -121,7 +121,6 @@ public class RemoteRemoteFileHandler extends RemoteFileHandler {
 		config.setErrFileName("lsErr.txt");
 		config.setOutFileName("lsOut.txt");
 		config.setNumProcs("1");
-		config.setWorkingDirectory("/notimportant");
 
 		CommandFactory factory = new CommandFactory();
 		Command lsCommand = factory.getCommand(config, connection.get().getConfiguration());

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileTransferCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileTransferCommand.java
@@ -181,6 +181,14 @@ public class RemoteRemoteFileTransferCommand extends RemoteCommand {
 	public void setRemoteHostCAuthorization(KeyPathConnectionAuthorizationHandler remoteHostC) {
 		this.remoteHostC = remoteHostC;
 	}
+	
+	/**
+	 * Getter for remotehost C keypath authorization
+	 * @return
+	 */
+	protected KeyPathConnectionAuthorizationHandler getRemoteHostCAuthorization() {
+		return remoteHostC;
+	}
 
 	/**
 	 * Function that sets the connection configuration and checks to make sure it is

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileTransferCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileTransferCommand.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.commands;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This class implements functionality to perform remote to remote file
+ * transfers where the two remote hosts are not the same. In other words, with
+ * the Commands API running on local host A, executing a transfer from remote
+ * host B to remote host C. The requirement for this to work is that remote host
+ * B must have an ssh key pair that connects it to remote host C, so that the
+ * connection can occur.
+ * 
+ * @author Joe Osborn
+ *
+ */
+public class RemoteRemoteFileTransferCommand extends RemoteCommand {
+
+	/**
+	 * A string containing the absolute path to the source on remote host B
+	 */
+	private String source;
+
+	/**
+	 * A string containing the absolute path to the destination on remote host C
+	 */
+	private String destination;
+
+	/**
+	 * The ConnectionAuthorizationHandler which will contain the necessary
+	 * configuration information to connect remote host B, where the source file is,
+	 * to remote host C, where the destination is. Required to be a keypath
+	 * connection
+	 */
+	private KeyPathConnectionAuthorizationHandler remoteHostC = null;
+
+	/**
+	 * Default constructor
+	 */
+	public RemoteRemoteFileTransferCommand() {
+		// Create a default CommandConfig to work with
+		commandConfig = new CommandConfiguration();
+	}
+
+	/**
+	 * Function which sets the two paths, source and destination, to those given by
+	 * the arguments. The ConnectionConfiguration also gives the remote connection
+	 * configuration for setting up the ssh and sftp channels to the remote host b.
+	 * 
+	 * @param src  - source file to be moved
+	 * @param dest - destination for source file to be moved to
+	 */
+	public void setConfiguration(String source, String destination) {
+		this.source = source;
+		this.destination = destination;
+		status = CommandStatus.PROCESSING;
+	}
+
+	/**
+	 * See {@link org.eclipse.ice.commands.Command#run()}
+	 */
+	@Override
+	protected CommandStatus run() {
+
+		status = processJob();
+
+		// Check the status to ensure file transfer was successful
+		if (!checkStatus(status))
+			return CommandStatus.FAILED;
+
+		status = monitorJob();
+
+		// Check the status to ensure file transfer was successful
+		if (!checkStatus(status))
+			return CommandStatus.FAILED;
+
+		status = finishJob();
+
+		return status;
+	}
+
+	/**
+	 * See {@link org.eclipse.ice.commands.RemoteCommand#finishJob()}
+	 */
+	@Override
+	protected CommandStatus finishJob() {
+		// Disconnect the channels and return success
+		try {
+			connection.get().getExecChannel().close();
+		} catch (IOException e) {
+			logger.error(e.getLocalizedMessage());
+		}
+		try {
+			connection.get().getSftpChannel().close();
+		} catch (IOException e) {
+			logger.error(e.getLocalizedMessage());
+		}
+
+		// Delete err and out files that were created
+		String outPath = commandConfig.getOutFileName();
+		String errPath = commandConfig.getErrFileName();
+		String workDir = commandConfig.getWorkingDirectory();
+		File outFile = new File(workDir + outPath);
+		File errFile = new File(workDir + errPath);
+		// Only delete if the command was successfull. If it wasn't, the files
+		// could be useful for debugging
+		if (status.equals(CommandStatus.SUCCESS)) {
+			if (!outFile.delete() || !errFile.delete()) {
+				logger.warn("Couldn't delete out/err file in directory " + workDir);
+			}
+		}
+
+		return status;
+	}
+
+	/**
+	 * Configures the CommandConfiguration to be run, which is just an scp command
+	 * utilizing the remoteHostC member variables
+	 * 
+	 * @return
+	 */
+	public void createCommand() {
+
+		String keypath = remoteHostC.getKeyPath();
+		String remoteHostCUser = remoteHostC.getUsername();
+		String remoteHostCHost = remoteHostC.getHostname();
+		String fullCommand = "scp -i " + keypath + " " + source + " " + remoteHostCUser + "@" + remoteHostCHost + ":"
+				+ destination;
+
+		commandConfig.setExecutable(fullCommand);
+		commandConfig.setAppendInput(false);
+		// Just set the remote working directory to be /tmp since it doesn't
+		// need a directory to work in
+		commandConfig.setRemoteWorkingDirectory("/tmp/");
+		commandConfig.setCommandId(9999);
+		commandConfig.setNumProcs("1");
+		// set working directory to current directory
+		commandConfig.setWorkingDirectory(System.getProperty("user.dir"));
+		// We'll set these and delete them at the end, so as to not create a bunch of
+		// err/out files
+		commandConfig.setErrFileName("scpErr.txt");
+		commandConfig.setOutFileName("scpOut.txt");
+
+		return;
+	}
+
+	/**
+	 * Get the source file string
+	 * 
+	 * @return - string of the source path
+	 */
+	public String getSource() {
+		return source;
+	}
+
+	/**
+	 * Get the destination file string
+	 * 
+	 * @return - string of the destination path
+	 */
+	public String getDestination() {
+		return destination;
+	}
+
+	/**
+	 * Set the connection information for connecting remote host B to remote host C
+	 * 
+	 * @param remoteHostC
+	 */
+	public void setRemoteHostCAuthorization(KeyPathConnectionAuthorizationHandler remoteHostC) {
+		this.remoteHostC = remoteHostC;
+	}
+
+	/**
+	 * Function that sets the connection configuration and checks to make sure it is
+	 * open. If it isn't, opens it
+	 */
+	@Override
+	public void setConnectionConfiguration(ConnectionConfiguration connectionConfig) {
+		this.connectionConfig = connectionConfig;
+		openAndSetConnection();
+	}
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileTransferCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileTransferCommand.java
@@ -41,7 +41,8 @@ public class RemoteRemoteFileTransferCommand extends RemoteCommand {
 	 * The ConnectionAuthorizationHandler which will contain the necessary
 	 * configuration information to connect remote host B, where the source file is,
 	 * to remote host C, where the destination is. Required to be a keypath
-	 * connection
+	 * connection for the authorization to work, should not be a generic
+	 * ConnectionAuthorizationHandler
 	 */
 	private KeyPathConnectionAuthorizationHandler remoteHostC = null;
 
@@ -102,7 +103,7 @@ public class RemoteRemoteFileTransferCommand extends RemoteCommand {
 			logger.error(e.getLocalizedMessage());
 		}
 		try {
-			if(connection.get().getSftpChannel() != null)
+			if (connection.get().getSftpChannel() != null)
 				connection.get().getSftpChannel().close();
 		} catch (IOException e) {
 			logger.error(e.getLocalizedMessage());
@@ -114,7 +115,7 @@ public class RemoteRemoteFileTransferCommand extends RemoteCommand {
 		String workDir = commandConfig.getWorkingDirectory();
 		File outFile = new File(workDir + outPath);
 		File errFile = new File(workDir + errPath);
-		// Only delete if the command was successfull. If it wasn't, the files
+		// Only delete if the command was successful. If it wasn't, the files
 		// could be useful for debugging
 		if (status.equals(CommandStatus.SUCCESS)) {
 			if (!outFile.delete() || !errFile.delete()) {
@@ -147,7 +148,7 @@ public class RemoteRemoteFileTransferCommand extends RemoteCommand {
 		commandConfig.setCommandId(9999);
 		commandConfig.setNumProcs("1");
 		// set working directory to current directory
-		//commandConfig.setWorkingDirectory(System.getProperty("user.dir"));
+		// commandConfig.setWorkingDirectory(System.getProperty("user.dir"));
 		// We'll set these and delete them at the end, so as to not create a bunch of
 		// err/out files
 		commandConfig.setErrFileName("scpErr.txt");
@@ -182,9 +183,10 @@ public class RemoteRemoteFileTransferCommand extends RemoteCommand {
 	public void setRemoteHostCAuthorization(KeyPathConnectionAuthorizationHandler remoteHostC) {
 		this.remoteHostC = remoteHostC;
 	}
-	
+
 	/**
 	 * Getter for remotehost C keypath authorization
+	 * 
 	 * @return
 	 */
 	protected KeyPathConnectionAuthorizationHandler getRemoteHostCAuthorization() {

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileTransferCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileTransferCommand.java
@@ -102,7 +102,8 @@ public class RemoteRemoteFileTransferCommand extends RemoteCommand {
 			logger.error(e.getLocalizedMessage());
 		}
 		try {
-			connection.get().getSftpChannel().close();
+			if(connection.get().getSftpChannel() != null)
+				connection.get().getSftpChannel().close();
 		} catch (IOException e) {
 			logger.error(e.getLocalizedMessage());
 		}
@@ -146,7 +147,7 @@ public class RemoteRemoteFileTransferCommand extends RemoteCommand {
 		commandConfig.setCommandId(9999);
 		commandConfig.setNumProcs("1");
 		// set working directory to current directory
-		commandConfig.setWorkingDirectory(System.getProperty("user.dir"));
+		//commandConfig.setWorkingDirectory(System.getProperty("user.dir"));
 		// We'll set these and delete them at the end, so as to not create a bunch of
 		// err/out files
 		commandConfig.setErrFileName("scpErr.txt");

--- a/org.eclipse.ice.commands/src/main/resources/log4j.properties
+++ b/org.eclipse.ice.commands/src/main/resources/log4j.properties
@@ -1,7 +1,11 @@
-# Root logger
-log4j.rootLogger=INFO, console
- 
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-#log4j.appender.console.Target=System.out
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.consoleAppender.layout.ConversionPattern=[%t] %-5p %c %x - %m%n
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=DEBUG, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+log4j.logger.org.apache.mina=ERROR
+log4j.logger.org.apache.sshd=ERROR

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.sshd.client.subsystem.sftp.SftpClient;
 import org.apache.sshd.client.subsystem.sftp.SftpClientFactory;
@@ -125,7 +126,7 @@ public class CommandFactoryTest {
 		rm += " somePythOutFile.txt somePythErrFile.txt someLsRemoteErrFile.txt someLsRemoteOutFile.txt";
 		rm += " src/test/java/org/eclipse/ice/tests/someInputFile.txt src/test/java/org/eclipse/ice/tests/someOtherInputFile.txt";
 		rm += " pythOutFile.txt pythErrFile.txt hopRemoteOutFile.txt hopRemoteErrFile.txt";
-		ArrayList<String> command = new ArrayList<String>();
+		List<String> command = new ArrayList<String>();
 		// Build a command
 		if (System.getProperty("os.name").toLowerCase().contains("win")) {
 			command.add("powershell.exe");
@@ -144,7 +145,7 @@ public class CommandFactoryTest {
 		Process job = builder.start();
 		job.waitFor(); // wait for it to finish
 
-		// Remove lal the connections that were opened in testing
+		// Remove all the connections that were opened in testing
 		ConnectionManager manager = ConnectionManagerFactory.getConnectionManager();
 		manager.removeAllConnections();
 

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/IFileHandlerFactoryTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/IFileHandlerFactoryTest.java
@@ -448,8 +448,7 @@ public class IFileHandlerFactoryTest {
 		config.setErrFileName("lsErr.txt");
 		config.setOutFileName("lsOut.txt");
 		config.setNumProcs("1");
-		// WD doesn't matter since we are rming with an absolute path
-		config.setWorkingDirectory("/tmp/doesnt/matter");
+	
 
 		// Get the command
 		CommandFactory factory = new CommandFactory();

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/IFileHandlerFactoryTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/IFileHandlerFactoryTest.java
@@ -38,6 +38,7 @@ import org.eclipse.ice.commands.IFileHandler;
 import org.eclipse.ice.commands.KeyPathConnectionAuthorizationHandler;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -92,7 +93,7 @@ public class IFileHandlerFactoryTest {
 	public static void tearDownAfterClass() throws Exception {
 		ConnectionManager manager = ConnectionManagerFactory.getConnectionManager();
 		manager.removeAllConnections();
-		
+
 		// Delete the output files that were created in the remote-remote test
 		RemoteRemoteFileTransferTest.tearDownAfterClass();
 	}
@@ -406,17 +407,22 @@ public class IFileHandlerFactoryTest {
 	 * @throws IOException
 	 */
 	@Test
+	@Ignore // ignore for now until we get second dummy host running
 	public void testRemoteRemoteFileTransfer() throws IOException {
+		// Create an instance of this test class to take advantage of file creation
+		// and deletion code in it
 		RemoteRemoteFileTransferTest transferTest = new RemoteRemoteFileTransferTest();
 		transferTest.setupConnectionConfigs();
 		ConnectionConfiguration remoteHostB = transferTest.getRemoteHostBConnectionConfig();
 		KeyPathConnectionAuthorizationHandler remoteHostC = transferTest.getRemoteHostCAuth();
 
+		// Setup the connection to move files
 		Connection bConn = ConnectionManagerFactory.getConnectionManager().openConnection(remoteHostB);
 		bConn.setSftpChannel(SftpClientFactory.instance().createSftpClient(bConn.getSession()));
 
 		transferTest.createRemoteHostBSourceFile();
 		theSource = transferTest.getSource();
+		// Just assume /tmp as the destination
 		theDestination = "/tmp/";
 
 		IFileHandler handler = factory.getFileHandler(remoteHostB, remoteHostC);
@@ -424,6 +430,10 @@ public class IFileHandlerFactoryTest {
 		// This checks existence, and regardless that check is handled by the unit test
 		CommandStatus status = handler.copy(theSource, theDestination);
 		assertTrue(status.equals(CommandStatus.SUCCESS));
+
+		// If this assertion passes, the test is by definition a success. The
+		// rest of the code in this test is just cleaning up additional files that were
+		// created during the test
 		transferTest.deleteHostBSource();
 
 		// Get the filename by splitting the path by "/"
@@ -448,7 +458,6 @@ public class IFileHandlerFactoryTest {
 		config.setErrFileName("lsErr.txt");
 		config.setOutFileName("lsOut.txt");
 		config.setNumProcs("1");
-	
 
 		// Get the command
 		CommandFactory factory = new CommandFactory();

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteFileHandlerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteFileHandlerTest.java
@@ -54,12 +54,12 @@ public class RemoteFileHandlerTest {
 	/**
 	 * A string containing the source file to move
 	 */
-	String theSource = "";
+	protected String theSource = "";
 
 	/**
 	 * A string containing the destination to move the source file to
 	 */
-	String theDestination = "";
+	protected String theDestination = "";
 
 	/**
 	 * A connection to use throughout the test
@@ -199,7 +199,7 @@ public class RemoteFileHandlerTest {
 
 		deleteLocalDestination();
 		deleteRemoteSource();
-	
+
 	}
 
 	/**
@@ -470,7 +470,7 @@ public class RemoteFileHandlerTest {
 		System.out.println("Moved source file to new remote source destination " + theSource);
 
 	}
-	
+
 	private void putFile(SftpClient client, String src, String dest) throws IOException {
 		if (dest.endsWith("/")) {
 			String separator = FileSystems.getDefault().getSeparator();
@@ -481,7 +481,7 @@ public class RemoteFileHandlerTest {
 		}
 		try (OutputStream dstStream = client.write(dest, OpenMode.Create, OpenMode.Write, OpenMode.Truncate)) {
 			try (InputStream srcStream = new FileInputStream(src)) {
-				byte[] buf = new byte[32*1024];
+				byte[] buf = new byte[32 * 1024];
 				while (srcStream.read(buf) > 0) {
 					dstStream.write(buf);
 				}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileHandlerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileHandlerTest.java
@@ -228,8 +228,6 @@ public class RemoteRemoteFileHandlerTest {
 		config.setErrFileName("lsErr.txt");
 		config.setOutFileName("lsOut.txt");
 		config.setNumProcs("1");
-		// WD doesn't matter since we are rming with an absolute path
-		config.setWorkingDirectory("/tmp/doesnt/matter");
 
 		// Get the command
 		CommandFactory factory = new CommandFactory();

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileHandlerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileHandlerTest.java
@@ -14,7 +14,6 @@ package org.eclipse.ice.tests.commands;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
-import java.nio.file.FileSystems;
 
 import org.apache.sshd.client.subsystem.sftp.SftpClientFactory;
 import org.eclipse.ice.commands.Command;
@@ -22,17 +21,16 @@ import org.eclipse.ice.commands.CommandConfiguration;
 import org.eclipse.ice.commands.CommandFactory;
 import org.eclipse.ice.commands.CommandStatus;
 import org.eclipse.ice.commands.Connection;
-import org.eclipse.ice.commands.ConnectionAuthorizationHandler;
-import org.eclipse.ice.commands.ConnectionAuthorizationHandlerFactory;
 import org.eclipse.ice.commands.ConnectionConfiguration;
 import org.eclipse.ice.commands.ConnectionManager;
 import org.eclipse.ice.commands.ConnectionManagerFactory;
 import org.eclipse.ice.commands.KeyPathConnectionAuthorizationHandler;
 import org.eclipse.ice.commands.RemoteRemoteFileHandler;
-import org.junit.After;
+
 import org.junit.AfterClass;
-import org.junit.Before;
+
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -79,19 +77,21 @@ public class RemoteRemoteFileHandlerTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
-		ConnectionManager manager = ConnectionManagerFactory.getConnectionManager();
+	//@BeforeClass
+	//@Ignore // ignore for now until we get second dummy host running
+	// Have to comment out because JUnit runs this by default
+	
+	//public static void setUpBeforeClass() throws Exception {
+	//	ConnectionManager manager = ConnectionManagerFactory.getConnectionManager();
+	//	makeRemoteHostConfigs();
 
-		makeRemoteHostConfigs();
-
-		bConn = manager.openConnection(remoteHostB);
+	//	bConn = manager.openConnection(remoteHostB);
 
 		// Setup the sftp channel to remote host b so that we can create dummy files
 		// and put them there immediately
-		bConn.setSftpChannel(SftpClientFactory.instance().createSftpClient(bConn.getSession()));
-	}
-
+	//	bConn.setSftpChannel(SftpClientFactory.instance().createSftpClient(bConn.getSession()));
+	//}
+	 
 	/**
 	 * Make the connection configurations for the two remote hosts
 	 * 
@@ -107,6 +107,7 @@ public class RemoteRemoteFileHandlerTest {
 	 * @throws java.lang.Exception
 	 */
 	@AfterClass
+	@Ignore // ignore for now until we get second dummy host running
 	public static void tearDownAfterClass() throws Exception {
 		ConnectionManagerFactory.getConnectionManager().closeAllConnections();
 		
@@ -121,6 +122,7 @@ public class RemoteRemoteFileHandlerTest {
 	 * @throws IOException
 	 */
 	@Test
+	@Ignore // ignore for now until we get second dummy host running
 	public void testCheckExistence() throws IOException {
 
 		transferTest.createRemoteHostBSourceFile();
@@ -144,6 +146,7 @@ public class RemoteRemoteFileHandlerTest {
 	 * @throws IOException
 	 */
 	@Test(expected = IOException.class)
+	@Ignore // ignore for now until we get second dummy host running
 	public void testCheckExistenceNonExistentSource() throws IOException {
 		destination = "/tmp/";
 
@@ -162,6 +165,7 @@ public class RemoteRemoteFileHandlerTest {
 	 * @throws IOException
 	 */
 	@Test(expected = IOException.class)
+	@Ignore // ignore for now until we get second dummy host running
 	public void testCheckExistenceNonExistentDestination() throws IOException {
 
 		transferTest.createRemoteHostBSourceFile();
@@ -192,6 +196,7 @@ public class RemoteRemoteFileHandlerTest {
 	 * @throws IOException
 	 */
 	@Test
+	@Ignore // ignore for now until we get second dummy host running
 	public void testMove() throws IOException {
 
 		transferTest.createRemoteHostBSourceFile();

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileHandlerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileHandlerTest.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.tests.commands;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+
+import org.apache.sshd.client.subsystem.sftp.SftpClientFactory;
+import org.eclipse.ice.commands.CommandStatus;
+import org.eclipse.ice.commands.Connection;
+import org.eclipse.ice.commands.ConnectionAuthorizationHandler;
+import org.eclipse.ice.commands.ConnectionAuthorizationHandlerFactory;
+import org.eclipse.ice.commands.ConnectionConfiguration;
+import org.eclipse.ice.commands.ConnectionManager;
+import org.eclipse.ice.commands.ConnectionManagerFactory;
+import org.eclipse.ice.commands.KeyPathConnectionAuthorizationHandler;
+import org.eclipse.ice.commands.RemoteRemoteFileHandler;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * This class tests the functionality of the RemoteRemoteFileHandler class,
+ * which contains the logic to perform file transfers from one remote system to
+ * another remote system
+ * 
+ * @author Joe Osborn
+ *
+ */
+public class RemoteRemoteFileHandlerTest {
+
+	/**
+	 * A source file to move around
+	 */
+	protected String source = "";
+
+	/**
+	 * A destination to move the source file
+	 */
+	protected String destination = "";
+
+	/**
+	 * The connection configuration for the remoteHostB where the source file lives
+	 */
+	protected static ConnectionConfiguration remoteHostB;
+
+	/**
+	 * A connection for remote host b
+	 */
+	protected static Connection bConn;
+
+	/**
+	 * The keypath authorization for remote host C
+	 */
+	protected static KeyPathConnectionAuthorizationHandler remoteHostCAuth;
+
+	/**
+	 * Create an instance of this class to take advantage of file creation/deletion
+	 * code
+	 */
+	static private RemoteRemoteFileTransferTest transferTest = new RemoteRemoteFileTransferTest();
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		ConnectionManager manager = ConnectionManagerFactory.getConnectionManager();
+
+		makeRemoteHostConfigs();
+
+		bConn = manager.openConnection(remoteHostB);
+
+		// Setup the sftp channel to remote host b so that we can create dummy files
+		// and put them there immediately
+		bConn.setSftpChannel(SftpClientFactory.instance().createSftpClient(bConn.getSession()));
+	}
+
+	/**
+	 * Make the connection configurations for the two remote hosts
+	 * 
+	 * @return
+	 */
+	private static void makeRemoteHostConfigs() {
+		transferTest.setupConnectionConfigs();
+		remoteHostB = transferTest.getRemoteHostBConnectionConfig();
+		remoteHostCAuth = transferTest.getRemoteHostCAuth();
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		ConnectionManagerFactory.getConnectionManager().closeAllConnections();
+	}
+
+	/**
+	 * This method tests the checkExistence function, which identifies the existence
+	 * of both the source and destination files
+	 * 
+	 * @throws IOException
+	 */
+	@Test
+	public void testCheckExistence() throws IOException {
+
+		transferTest.createRemoteHostBSourceFile();
+		source = transferTest.getSource();
+		destination = "/tmp/";
+
+		RemoteRemoteFileHandler handler = new RemoteRemoteFileHandler();
+		handler.setConnectionConfiguration(remoteHostB);
+		handler.setDestinationAuthorization(remoteHostCAuth);
+
+		// This should not throw an exception. No exception == success
+		handler.checkExistence(source, destination);
+
+		transferTest.deleteHostBSource();
+
+	}
+
+	/**
+	 * This tests checkExistence with a nonexistent source file. Expected exception
+	 * 
+	 * @throws IOException
+	 */
+	@Test(expected = IOException.class)
+	public void testCheckExistenceNonExistentSource() throws IOException {
+		destination = "/tmp/";
+
+		RemoteRemoteFileHandler handler = new RemoteRemoteFileHandler();
+		handler.setConnectionConfiguration(remoteHostB);
+		handler.setDestinationAuthorization(remoteHostCAuth);
+
+		handler.checkExistence("/nonexistent/source/file.txt", destination);
+
+	}
+
+	/**
+	 * This tests checkExistence with a nonexistent destination directory. Expected
+	 * exception
+	 * 
+	 * @throws IOException
+	 */
+	@Test(expected = IOException.class)
+	public void testCheckExistenceNonExistentDestination() throws IOException {
+
+		transferTest.createRemoteHostBSourceFile();
+		source = transferTest.getSource();
+
+		RemoteRemoteFileHandler handler = new RemoteRemoteFileHandler();
+		handler.setConnectionConfiguration(remoteHostB);
+		handler.setDestinationAuthorization(remoteHostCAuth);
+
+		handler.checkExistence(source, "/nonexistent/destination/");
+
+		transferTest.deleteHostBSource();
+
+	}
+
+	/**
+	 * Tests both the move function and the exists function, since they can be used
+	 * in tandem together
+	 * 
+	 * We only test the move command since the copy command from the
+	 * RemoteRemoteFileHandler calls the same function, since an scp does the same
+	 * thing as both move and copy
+	 * 
+	 * @throws IOException
+	 */
+	@Test
+	public void testMove() throws IOException {
+
+		transferTest.createRemoteHostBSourceFile();
+		source = transferTest.getSource();
+		destination = "/tmp/";
+
+		RemoteRemoteFileHandler handler = new RemoteRemoteFileHandler();
+		handler.setConnectionConfiguration(remoteHostB);
+		handler.setDestinationAuthorization(remoteHostCAuth);
+
+		// This also tests exists function, which is really tested by checkExistence
+		// test above
+		CommandStatus status = handler.move(source, destination);
+		assertTrue(status.equals(CommandStatus.SUCCESS));
+		transferTest.deleteHostBSource();
+
+	}
+
+}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileTransferTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileTransferTest.java
@@ -76,7 +76,7 @@ public class RemoteRemoteFileTransferTest {
 	 * Remote host C key path that is needed to establish connection between host B
 	 * and host C
 	 */
-	String remoteHostCKeyPath = "/home/4jo/.ssh/dummykey";
+	String remoteHostCKeyPath = "/some/key";
 
 	/**
 	 * Authorization for remote host C
@@ -245,9 +245,9 @@ public class RemoteRemoteFileTransferTest {
 		hostBConnection = new ConnectionConfiguration();
 		hostBConnection.setName("hostB");
 		ConnectionAuthorizationHandler bauth = new KeyPathConnectionAuthorizationHandler();
-		bauth.setHostname("denisovan");
-		bauth.setUsername("4jo");
-		bauth.setOption("/home/4jo/.ssh/denisovankey");
+		bauth.setHostname("host");
+		bauth.setUsername("user");
+		bauth.setOption(System.getProperty("user.home") + "/.ssh/somekey");
 
 		hostBConnection.setAuthorization(bauth);
 
@@ -288,9 +288,7 @@ public class RemoteRemoteFileTransferTest {
 		config.setErrFileName("lsErr.txt");
 		config.setOutFileName("lsOut.txt");
 		config.setNumProcs("1");
-		// WD doesn't matter since we are lsing with an absolute path
-		config.setWorkingDirectory("/tmp/doesnt/matter");
-
+	
 		// Get the command
 		CommandFactory factory = new CommandFactory();
 		Command Command = factory.getCommand(config, hostBConnection);
@@ -313,8 +311,6 @@ public class RemoteRemoteFileTransferTest {
 		config.setErrFileName("lsErr.txt");
 		config.setOutFileName("lsOut.txt");
 		config.setNumProcs("1");
-		// WD doesn't matter since we are rming with an absolute path
-		config.setWorkingDirectory("/tmp/doesnt/matter");
 
 		// Get the command
 		Command rmCommand = factory.getCommand(config, hostBConnection);

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileTransferTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileTransferTest.java
@@ -76,7 +76,7 @@ public class RemoteRemoteFileTransferTest {
 	 * Remote host C key path that is needed to establish connection between host B
 	 * and host C
 	 */
-	String remoteHostCKeyPath = "/home/4jo/.ssh/dummykey";
+	String remoteHostCKeyPath = "/path/to/keykey";
 
 	/**
 	 * Authorization for remote host C
@@ -88,7 +88,7 @@ public class RemoteRemoteFileTransferTest {
 	 */
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		RemoteFileHandlerTest.setUpBeforeClass();
+
 	}
 
 	/**
@@ -130,7 +130,7 @@ public class RemoteRemoteFileTransferTest {
 	 * @throws Exception
 	 */
 	@Test
-	@Ignore // ignore for now until we get second dummy host running
+	// @Ignore // ignore for now until we get second dummy host running
 	public void testRemoteRemoteFileTransfer() throws Exception {
 		System.out.println("Testing RemoteRemote \n\n\n");
 
@@ -145,8 +145,10 @@ public class RemoteRemoteFileTransferTest {
 		command.createCommand();
 		CommandStatus status = command.execute();
 
+		// Check that command completed correctly
 		assertEquals(CommandStatus.SUCCESS, status);
 
+		// Check if file transfer was successful and deletes the moved file on host C
 		assertTrue(checkPathExistsRemoteHostC());
 
 		// Now clean up the file created
@@ -154,7 +156,12 @@ public class RemoteRemoteFileTransferTest {
 		System.out.println("End Test \n\n\n");
 	}
 
-	private void deleteHostBSource() throws IOException {
+	/**
+	 * Deletes the source file from the remote host B
+	 * 
+	 * @throws IOException
+	 */
+	protected void deleteHostBSource() throws IOException {
 		Connection conn = ConnectionManagerFactory.getConnectionManager().getConnection(hostBConnection.getName());
 		conn.setSftpChannel(SftpClientFactory.instance().createSftpClient(conn.getSession()));
 		SftpClient channel = conn.getSftpChannel();
@@ -166,7 +173,7 @@ public class RemoteRemoteFileTransferTest {
 	 * 
 	 * @throws IOException
 	 */
-	private void createRemoteHostBSourceFile() throws IOException {
+	protected void createRemoteHostBSourceFile() throws IOException {
 		Connection conn = ConnectionManagerFactory.getConnectionManager().openConnection(hostBConnection);
 		conn.setSftpChannel(SftpClientFactory.instance().createSftpClient(conn.getSession()));
 		SftpClient sftpChannel = conn.getSftpChannel();
@@ -227,10 +234,9 @@ public class RemoteRemoteFileTransferTest {
 	}
 
 	/**
-	 * Private function that just sets up the connection information for the test to
-	 * run
+	 * Function that just sets up the connection information for the test to run
 	 */
-	private void setupConnectionConfigs() {
+	protected void setupConnectionConfigs() {
 		remoteHostC = new KeyPathConnectionAuthorizationHandler();
 		remoteHostC.setUsername("dummy");
 		remoteHostC.setHostname("osbornjd-ice-host.ornl.gov");
@@ -252,7 +258,7 @@ public class RemoteRemoteFileTransferTest {
 	 * 
 	 * @throws IOException
 	 */
-	private boolean checkPathExistsRemoteHostC() throws IOException {
+	protected boolean checkPathExistsRemoteHostC() throws IOException {
 
 		// Get the filename by splitting the path by "/"
 		String separator = "/";
@@ -318,6 +324,30 @@ public class RemoteRemoteFileTransferTest {
 		if (!status.equals(CommandStatus.SUCCESS))
 			System.out.println("Couldn't delete destination file at : " + destination);
 		return true;
+	}
+
+	/**
+	 * Add some functions that can be used by other classes to take advantage of the
+	 * file creation and deletion code that was already created here
+	 */
+	public RemoteRemoteFileTransferTest() {
+
+	}
+
+	protected ConnectionConfiguration getRemoteHostBConnectionConfig() {
+		return hostBConnection;
+	}
+
+	protected KeyPathConnectionAuthorizationHandler getRemoteHostCAuth() {
+		return remoteHostC;
+	}
+
+	protected String getSource() {
+		return source;
+	}
+
+	protected String getDestination() {
+		return destination;
 	}
 
 }

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileTransferTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileTransferTest.java
@@ -76,7 +76,7 @@ public class RemoteRemoteFileTransferTest {
 	 * Remote host C key path that is needed to establish connection between host B
 	 * and host C
 	 */
-	String remoteHostCKeyPath = "/path/to/keykey";
+	String remoteHostCKeyPath = "/home/4jo/.ssh/dummykey";
 
 	/**
 	 * Authorization for remote host C
@@ -245,9 +245,9 @@ public class RemoteRemoteFileTransferTest {
 		hostBConnection = new ConnectionConfiguration();
 		hostBConnection.setName("hostB");
 		ConnectionAuthorizationHandler bauth = new KeyPathConnectionAuthorizationHandler();
-		bauth.setHostname("host");
-		bauth.setUsername("user");
-		bauth.setOption("/path/to/key");
+		bauth.setHostname("denisovan");
+		bauth.setUsername("4jo");
+		bauth.setOption("/home/4jo/.ssh/denisovankey");
 
 		hostBConnection.setAuthorization(bauth);
 
@@ -323,6 +323,7 @@ public class RemoteRemoteFileTransferTest {
 		// Just warn, since it isn't a huge deal if a file wasn't successfully deleted
 		if (!status.equals(CommandStatus.SUCCESS))
 			System.out.println("Couldn't delete destination file at : " + destination);
+		
 		return true;
 	}
 

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileTransferTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteRemoteFileTransferTest.java
@@ -1,0 +1,323 @@
+/*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.tests.commands;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.sshd.client.subsystem.sftp.SftpClient;
+import org.apache.sshd.client.subsystem.sftp.SftpClient.OpenMode;
+import org.apache.sshd.client.subsystem.sftp.SftpClientFactory;
+import org.eclipse.ice.commands.Command;
+import org.eclipse.ice.commands.CommandConfiguration;
+import org.eclipse.ice.commands.CommandFactory;
+import org.eclipse.ice.commands.CommandStatus;
+import org.eclipse.ice.commands.Connection;
+import org.eclipse.ice.commands.ConnectionAuthorizationHandler;
+import org.eclipse.ice.commands.ConnectionAuthorizationHandlerFactory;
+import org.eclipse.ice.commands.ConnectionConfiguration;
+import org.eclipse.ice.commands.ConnectionManagerFactory;
+import org.eclipse.ice.commands.HandleType;
+import org.eclipse.ice.commands.KeyPathConnectionAuthorizationHandler;
+import org.eclipse.ice.commands.RemoteRemoteFileTransferCommand;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * This class tests remote to remote file transfers executed from a local host
+ * A, i.e. from host A a remote file transfer between host B and host C
+ * 
+ * @author Joe Osborn
+ *
+ */
+public class RemoteRemoteFileTransferTest {
+
+	/**
+	 * A source file to use for testing
+	 */
+	String source = "";
+
+	/**
+	 * A destination to move the file
+	 */
+	String destination = "/tmp/";
+
+	/**
+	 * Connection information for host B
+	 */
+	ConnectionConfiguration hostBConnection;
+
+	/**
+	 * Remote host C key path that is needed to establish connection between host B
+	 * and host C
+	 */
+	String remoteHostCKeyPath = "/home/4jo/.ssh/dummykey";
+
+	/**
+	 * Authorization for remote host C
+	 */
+	KeyPathConnectionAuthorizationHandler remoteHostC;
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		RemoteFileHandlerTest.setUpBeforeClass();
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		// Delete the extra output files that were made during clean up
+		String rm = "lsOut.txt lsErr.txt";
+
+		List<String> command = new ArrayList<String>();
+		// Build a command
+		if (System.getProperty("os.name").toLowerCase().contains("win")) {
+			command.add("powershell.exe");
+		} else {
+			command.add("/bin/bash");
+			command.add("-c");
+		}
+		command.add("rm " + rm);
+
+		// Execute the command with the process builder api
+		ProcessBuilder builder = new ProcessBuilder(command);
+		// Files exist in the top most directory of the package
+		String topDir = System.getProperty("user.dir");
+		File file = new File(topDir);
+		builder.directory(file);
+		// Process it
+		Process job = builder.start();
+		job.waitFor(); // wait for it to finish
+
+		// Remove connections
+		ConnectionManagerFactory.getConnectionManager().removeAllConnections();
+	}
+
+	/**
+	 * A test function to test the remote to remote file transfer functionality,
+	 * where the file transfer goes from one remote host B to another remote host C
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	@Ignore // ignore for now until we get second dummy host running
+	public void testRemoteRemoteFileTransfer() throws Exception {
+		System.out.println("Testing RemoteRemote \n\n\n");
+
+		setupConnectionConfigs();
+
+		createRemoteHostBSourceFile();
+
+		RemoteRemoteFileTransferCommand command = new RemoteRemoteFileTransferCommand();
+		command.setConnectionConfiguration(hostBConnection);
+		command.setRemoteHostCAuthorization(remoteHostC);
+		command.setConfiguration(source, destination);
+		command.createCommand();
+		CommandStatus status = command.execute();
+
+		assertEquals(CommandStatus.SUCCESS, status);
+
+		assertTrue(checkPathExistsRemoteHostC());
+
+		// Now clean up the file created
+		deleteHostBSource();
+		System.out.println("End Test \n\n\n");
+	}
+
+	private void deleteHostBSource() throws IOException {
+		Connection conn = ConnectionManagerFactory.getConnectionManager().getConnection(hostBConnection.getName());
+		conn.setSftpChannel(SftpClientFactory.instance().createSftpClient(conn.getSession()));
+		SftpClient channel = conn.getSftpChannel();
+		channel.remove(source);
+	}
+
+	/**
+	 * Creates a source file to play with on remote host B
+	 * 
+	 * @throws IOException
+	 */
+	private void createRemoteHostBSourceFile() throws IOException {
+		Connection conn = ConnectionManagerFactory.getConnectionManager().openConnection(hostBConnection);
+		conn.setSftpChannel(SftpClientFactory.instance().createSftpClient(conn.getSession()));
+		SftpClient sftpChannel = conn.getSftpChannel();
+		String hostBsource = "/tmp/";
+
+		try {
+			sftpChannel.lstat(hostBsource);
+		} catch (Exception e) {
+			System.out.println("Remote directory not found, trying to make it for source file.");
+			sftpChannel.mkdir(hostBsource);
+		}
+
+		// Create a dummy file to test
+		String src = "remoteRemoteDummyfile.txt";
+		Path sourcePath = null;
+		try {
+			sourcePath = Files.createTempFile(null, src);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		// Get the filename by splitting the path by "/"
+		String separator = FileSystems.getDefault().getSeparator();
+		if (System.getProperty("os.name").toLowerCase().contains("win"))
+			separator += "\\";
+		String[] tokens = sourcePath.toString().split(separator);
+
+		// Get the last index of tokens, which will be the filename
+		String filename = tokens[tokens.length - 1];
+
+		if (hostBsource.endsWith("/")) {
+			hostBsource += filename;
+		}
+
+		try (OutputStream dstStream = sftpChannel.write(hostBsource, OpenMode.Create, OpenMode.Write,
+				OpenMode.Truncate)) {
+			try (InputStream srcStream = new FileInputStream(sourcePath.toString())) {
+				byte[] buf = new byte[32 * 1024];
+				while (srcStream.read(buf) > 0) {
+					dstStream.write(buf);
+				}
+			}
+		}
+
+		// Delete the local directory that was created since it is no longer needed
+		Path path = Paths.get(sourcePath.toString());
+
+		try {
+			Files.deleteIfExists(path);
+		} catch (NoSuchFileException e) {
+			// If somehow the directory doesn't exist, indicate so
+			System.err.format("%s: somehow this path doesn't exist... no such" + " file or directory%n", path);
+			e.printStackTrace();
+		}
+
+		// set the source string in this class to that just created
+		source = hostBsource;
+	}
+
+	/**
+	 * Private function that just sets up the connection information for the test to
+	 * run
+	 */
+	private void setupConnectionConfigs() {
+		remoteHostC = new KeyPathConnectionAuthorizationHandler();
+		remoteHostC.setUsername("dummy");
+		remoteHostC.setHostname("osbornjd-ice-host.ornl.gov");
+		remoteHostC.setOption(remoteHostCKeyPath);
+
+		hostBConnection = new ConnectionConfiguration();
+		hostBConnection.setName("hostB");
+		ConnectionAuthorizationHandler bauth = new KeyPathConnectionAuthorizationHandler();
+		bauth.setHostname("host");
+		bauth.setUsername("user");
+		bauth.setOption("/path/to/key");
+
+		hostBConnection.setAuthorization(bauth);
+
+	}
+
+	/**
+	 * This function checks if the file was properly moved to the remote host C
+	 * 
+	 * @throws IOException
+	 */
+	private boolean checkPathExistsRemoteHostC() throws IOException {
+
+		// Get the filename by splitting the path by "/"
+		String separator = "/";
+		if (source.contains("\\"))
+			separator = "\\";
+
+		String[] tokens = source.split(separator);
+		String filename = tokens[tokens.length - 1];
+
+		// add the file name to the destination
+		if (!destination.endsWith(separator))
+			destination += separator;
+
+		destination += filename;
+
+		// Create a remote command to ls the remote path
+
+		String command = "ssh -i " + remoteHostCKeyPath + " " + remoteHostC.getUsername() + "@"
+				+ remoteHostC.getHostname();
+		command += " \"ls " + destination + "\"";
+
+		// Create the command configuration
+		CommandConfiguration config = new CommandConfiguration();
+		config.setExecutable(command);
+		config.setAppendInput(false);
+		config.setCommandId(99);
+		config.setErrFileName("lsErr.txt");
+		config.setOutFileName("lsOut.txt");
+		config.setNumProcs("1");
+		// WD doesn't matter since we are lsing with an absolute path
+		config.setWorkingDirectory("/tmp/doesnt/matter");
+
+		// Get the command
+		CommandFactory factory = new CommandFactory();
+		Command Command = factory.getCommand(config, hostBConnection);
+
+		CommandStatus status = Command.execute();
+
+		// If the command was successful, it means that it could successfully ls
+		// indicating that the file was there.
+		if (!status.equals(CommandStatus.SUCCESS))
+			return false;
+
+		// Delete the file that was moved with another command
+		command = "ssh -i " + remoteHostCKeyPath + " " + remoteHostC.getUsername() + "@" + remoteHostC.getHostname();
+		command += " \"rm " + destination + "\"";
+
+		config = new CommandConfiguration();
+		config.setExecutable(command);
+		config.setAppendInput(false);
+		config.setCommandId(99);
+		config.setErrFileName("lsErr.txt");
+		config.setOutFileName("lsOut.txt");
+		config.setNumProcs("1");
+		// WD doesn't matter since we are rming with an absolute path
+		config.setWorkingDirectory("/tmp/doesnt/matter");
+
+		// Get the command
+		Command rmCommand = factory.getCommand(config, hostBConnection);
+
+		status = rmCommand.execute();
+		// Just warn, since it isn't a huge deal if a file wasn't successfully deleted
+		if (!status.equals(CommandStatus.SUCCESS))
+			System.out.println("Couldn't delete destination file at : " + destination);
+		return true;
+	}
+
+}


### PR DESCRIPTION
This PR implements the capability for remote to remote file transfers to occur through the API. One could also implement a command which runs a script that contains the logic to do this, i.e. 
```
#!/bin/bash
scp -i /path/to/key someFile.txt username@hostname:/new/path/on/host/
```
The result is identical - but it is perhaps easier to call the file transfer through the Commands API.

Tests are ignored by default for the moment because of the lack of a second dummy host to test on. However tests pass locally and on windows when the proper key configuration is setup.